### PR TITLE
Apply aesthetic quality ranking to random search

### DIFF
--- a/app/application/usecase.py
+++ b/app/application/usecase.py
@@ -325,6 +325,14 @@ class Usecase:
             index=index,
             query_features=features,
         )
+        scores = self.aesthetic_quality_eval(
+            model_id,
+            scores,
+            aesthetic_quality_beta,
+            aesthetic_quality_range_min,
+            aesthetic_quality_range_max,
+            aesthetic_model_name,
+        )
         return ResultImageItemList(scores, self.format_search_query(features))
 
     def search_query(


### PR DESCRIPTION
## Summary
- include aesthetic re-ranking inside the random search operation

## Testing
- `python -m py_compile app/application/usecase.py`


------
https://chatgpt.com/codex/tasks/task_e_6858b7beb3e883249149c630f68fddf2