### PR TITLE
Add file classification utility with tests

### DIFF
--- a/app/presentation/file_utils.py
+++ b/app/presentation/file_utils.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pathlib
+
+# Allowed extensions for different file categories
+ALLOWED_IMAGE = {
+    'jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'tiff'
+}
+ALLOWED_VIDEO = {
+    'mp4', 'avi', 'mov', 'mkv', 'webm'
+}
+ALLOWED_TEXT = {
+    'txt', 'md', 'json', 'csv', 'html', 'htm'
+}
+
+def file_category(filename: str) -> str | None:
+    """Return the category of the file based on its extension.
+
+    Parameters
+    ----------
+    filename: str
+        Name of the file to inspect.
+
+    Returns
+    -------
+    str | None
+        ``"image"`` if the extension is recognised as an image,
+        ``"video"`` if it is a video,
+        ``"text"`` if it is a text file, otherwise ``None``.
+    """
+    ext = pathlib.Path(filename).suffix.lower().lstrip('.')
+    if ext in ALLOWED_IMAGE:
+        return 'image'
+    if ext in ALLOWED_VIDEO:
+        return 'video'
+    if ext in ALLOWED_TEXT:
+        return 'text'
+    return None

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.presentation.file_utils import (
+    ALLOWED_IMAGE,
+    ALLOWED_VIDEO,
+    ALLOWED_TEXT,
+    file_category,
+)
+
+
+def test_file_category_image():
+    for ext in ALLOWED_IMAGE:
+        assert file_category(f"dummy.{ext}") == "image"
+        assert file_category(f"dummy.{ext.upper()}") == "image"
+
+
+def test_file_category_video():
+    for ext in ALLOWED_VIDEO:
+        assert file_category(f"movie.{ext}") == "video"
+        assert file_category(f"movie.{ext.upper()}") == "video"
+
+
+def test_file_category_text():
+    for ext in ALLOWED_TEXT:
+        assert file_category(f"file.{ext}") == "text"
+        assert file_category(f"file.{ext.upper()}") == "text"
+
+
+def test_file_category_unknown():
+    assert file_category("example.bin") is None


### PR DESCRIPTION
## Summary
- implement `file_category` with extension sets
- add unit tests covering file classification

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b70482a988324870b10206d5ad6d8