### PR TITLE
Add thumbnail image endpoint and caching

### DIFF
--- a/app/application/usecase.py
+++ b/app/application/usecase.py
@@ -55,6 +55,11 @@ class Usecase:
 
         return self._repository.load_image(id)
 
+    def get_small_image(self, id: ImageId) -> Image:
+        """画像IDから縮小画像を取得する"""
+
+        return self._repository.load_small_image(id)
+
     # ===================================================================
 
     def get_all_model(self) -> list[ModelItem]:

--- a/app/domain/repository.py
+++ b/app/domain/repository.py
@@ -20,6 +20,11 @@ class Repository(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def load_small_image(self, image_id: ImageId) -> Image:
+
+        pass
+
+    @abstractmethod
     def load_all_model_item(self) -> list[ModelItem]:
 
         pass

--- a/app/presentation/controller.py
+++ b/app/presentation/controller.py
@@ -93,11 +93,20 @@ def get_image_item(id: str):
     return from_image_item_to_json(usecase.get_image_item(ImageId(id)))
 
 
-@app.route("/image_item/<id>/image")
-def get_image(id: str):
-    """画像IDから画像を返す"""
+@app.route("/image/<id>/small")
+def get_small_image(id: str):
+    """画像IDから縮小画像を返す"""
 
-    # 画像を取得して、レスポンスに詰め替えて返す。
+    img = usecase.get_small_image(ImageId(id))
+    response = make_response(img.binary)
+    response.headers.set('Content-Type', img.content_type)
+    return response
+
+
+@app.route("/image/<id>/original")
+def get_original_image(id: str):
+    """画像IDからオリジナル画像を返す"""
+
     img = usecase.get_image(ImageId(id))
     response = make_response(img.binary)
     response.headers.set('Content-Type', img.content_type)

--- a/app/presentation/view/index.html
+++ b/app/presentation/view/index.html
@@ -108,7 +108,7 @@
                             :data-index="index"
                             :data-selected="selectedItemId[item.id]"
                             >
-                                <v-img :src="item.img" :title="item.img_name" height="200" transition="false" v-show="true">
+                                <v-img :src="item.img_small" :title="item.img_name" height="200" transition="false" v-show="true">
                                     <v-btn icon>
                                         <v-icon icon="mdi-arrow-expand-all" color="info"></v-icon>
                                         <v-dialog
@@ -116,10 +116,10 @@
                                             width="auto"
                                         >
                                             <v-card>
-                                                <v-img :src="item.img" :title="item.img_name" width="90vw" height="85vh"></v-img>
+                                                <v-img :src="item.img_original" :title="item.img_name" width="90vw" height="85vh"></v-img>
                                                 <v-card-title>
                                                     <span class="meta">{{ item.img_name }}</span>
-                                                    <a :href="item.img" :download="item.img_name.split('\\').pop()">
+                                                    <a :href="item.img_original" :download="item.img_name.split('\\').pop()">
                                                         <v-icon icon="mdi-download" color="info"></v-icon>
                                                     </a>
                                                 </v-card-title>

--- a/app/presentation/view/js/main.js
+++ b/app/presentation/view/js/main.js
@@ -7,7 +7,7 @@ import * as util from "./util.js"
 
 
 /**
- * @typedef {{id: string, score: number, img_name: string, img: string, selected: boolean}} DisplayItem
+ * @typedef {{id: string, score: number, img_name: string, img_small: string, img_original: string, selected: boolean}} DisplayItem
  */
 
 const vuetify = Vuetify.createVuetify()
@@ -180,7 +180,8 @@ const app = Vue.createApp({
                     score: result.score,
                     tags: result.item.tags,
                     img_name: result.item.name,
-                    img: repository.getImageUrl(result.item.id),
+                    img_small: repository.getImageSmallUrl(result.item.id),
+                    img_original: repository.getImageOriginalUrl(result.item.id),
                     selected: false
                 });
             });

--- a/app/presentation/view/js/modules/repository.js
+++ b/app/presentation/view/js/modules/repository.js
@@ -19,9 +19,12 @@ import { fileToBase64 } from "./util.js"
  * 
  * @return {string}
  */
-export function getImageUrl(itemId) {
+export function getImageSmallUrl(itemId) {
+    return `/image/${itemId}/small`
+}
 
-    return `/image_item/${itemId}/image`
+export function getImageOriginalUrl(itemId) {
+    return `/image/${itemId}/original`
 }
 
 


### PR DESCRIPTION
## Summary
- create `/image/<id>/small` and `/image/<id>/original` endpoints
- generate 400px thumbnails in `LocalRepository` with in-memory caching
- update `Repository` interface and `Usecase`
- adjust frontend to show thumbnails in lists and original images in dialogs/downloads

## Testing
- `python -m py_compile app/domain/repository.py app/infrastructure/local_repository.py app/application/usecase.py app/presentation/controller.py`

------
https://chatgpt.com/codex/tasks/task_e_68842fce575c8324bfe8e58fa8c3d119