### PR TITLE
起動時のメタデータ読み込みを選択モデルDBに限定

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import pathlib
 
 from app.infrastructure.local_accessor import LocalAccessor
 from app.infrastructure.local_repository import LocalRepository
+from app.domain.domain_object import ModelId
 
 from app.presentation.controller import start_app
 from app.application import usecase
@@ -19,8 +20,11 @@ def main():
     accessor: LocalAccessor = LocalAccessor(meta_dir_path)
 
     repository: LocalRepository = LocalRepository(image_dir_path)
+    startup_model_id = ModelId("ViT-L-14", "openai")
 
-    in_usecase: usecase.Usecase = usecase.Usecase(repository, accessor)
+    in_usecase: usecase.Usecase = usecase.Usecase(
+        repository, accessor, startup_model_id
+    )
     start_app(in_usecase)
 
 

--- a/app/application/accessor.py
+++ b/app/application/accessor.py
@@ -37,6 +37,7 @@ class Accessor():
     @abstractmethod
     def load_startup_image_items(
         self,
+        model_id: ModelId,
     ) -> tuple[list[ImageItem], dict[ImageId, pathlib.Path]]:
         """起動時表示用の画像一覧とImageId->相対パスマップを読み込む"""
 

--- a/app/application/usecase.py
+++ b/app/application/usecase.py
@@ -29,7 +29,12 @@ from app.domain.repository import Repository
 class Usecase:
     """このアプリケーションの動作を実装するクラス"""
 
-    def __init__(self, repository: Repository, accessor: Accessor) -> None:
+    def __init__(
+        self,
+        repository: Repository,
+        accessor: Accessor,
+        startup_model_id: ModelId,
+    ) -> None:
         self._logger = logging.getLogger(__name__)
         self._repository: Repository = repository
         self._accessor: Accessor = accessor
@@ -37,7 +42,9 @@ class Usecase:
         self._image_items: list[ImageItem] = []
 
         # 起動時はDBのメタ情報から画像項目を読み込む（失敗時のみ従来の全走査へフォールバック）
-        startup_items, image_paths = self._accessor.load_startup_image_items()
+        startup_items, image_paths = self._accessor.load_startup_image_items(
+            startup_model_id
+        )
         if startup_items:
             self._repository.set_image_paths(image_paths)
             self._image_items = startup_items

--- a/app/infrastructure/dummy_accessor.py
+++ b/app/infrastructure/dummy_accessor.py
@@ -24,5 +24,6 @@ class DummyAccessor(Accessor):
 
     def load_startup_image_items(
         self,
+        model_id: ModelId,
     ) -> tuple[list[ImageItem], dict[ImageId, pathlib.Path]]:
         return [], {}

--- a/app/infrastructure/local_accessor.py
+++ b/app/infrastructure/local_accessor.py
@@ -101,49 +101,53 @@ class LocalAccessor(Accessor):
     @cache
     def load_startup_image_items(
         self,
+        model_id: ModelId,
     ) -> tuple[list[ImageItem], dict[ImageId, pathlib.Path]]:
         """起動時に必要な画像一覧とImageId->相対パスをSQLiteから構築して返す。"""
 
         startup_items_by_id: dict[ImageId, ImageItem] = {}
         id_to_path: dict[ImageId, pathlib.Path] = {}
-        db_paths = sorted(self._meta_dir_path.glob("*/sqlite_image_meta.db"))
+        db_path = (
+            self._meta_dir_path
+            / f"{model_id.model_name}-{model_id.pretrained}"
+            / "sqlite_image_meta.db"
+        )
 
-        if not db_paths:
+        if not db_path.exists():
             self._logger.warning(
                 "起動用のsqlite_image_meta.dbが見つかりません: %s",
-                self._meta_dir_path,
+                db_path,
             )
             return [], {}
 
-        for db_path in db_paths:
-            con: sqlite3.Connection = sqlite3.connect(
-                db_path,
-                isolation_level="DEFERRED",
+        con: sqlite3.Connection = sqlite3.connect(
+            db_path,
+            isolation_level="DEFERRED",
+        )
+        try:
+            result: pd.DataFrame = pd.read_sql_query(
+                """
+                SELECT image_id, image_path, image_tags
+                FROM image_meta
+                """,
+                con,
             )
-            try:
-                result: pd.DataFrame = pd.read_sql_query(
-                    """
-                    SELECT image_id, image_path, image_tags
-                    FROM image_meta
-                    """,
-                    con,
-                )
-            finally:
-                con.close()
+        finally:
+            con.close()
 
-            for row in result.itertuples(index=False):
-                image_id = ImageId(str(row.image_id))
-                if image_id in startup_items_by_id:
-                    continue
+        for row in result.itertuples(index=False):
+            image_id = ImageId(str(row.image_id))
+            if image_id in startup_items_by_id:
+                continue
 
-                image_path = pathlib.Path(str(row.image_path))
-                tags = row.image_tags if row.image_tags is not None else ""
-                startup_items_by_id[image_id] = ImageItem(
-                    id=image_id,
-                    display_name=ImageName(str(image_path)),
-                    tags=ImageTags(tags),
-                )
-                id_to_path[image_id] = image_path
+            image_path = pathlib.Path(str(row.image_path))
+            tags = row.image_tags if row.image_tags is not None else ""
+            startup_items_by_id[image_id] = ImageItem(
+                id=image_id,
+                display_name=ImageName(str(image_path)),
+                tags=ImageTags(tags),
+            )
+            id_to_path[image_id] = image_path
 
         startup_items = sorted(
             startup_items_by_id.values(),


### PR DESCRIPTION
### Motivation
- 起動時のメタデータ読み込みを`meta_dir`以下の全DB走査から、指定モデルのDBのみ（`{model_id.model_name}-{model_id.pretrained}/sqlite_image_meta.db`）を読む挙動に変え、不要な重複読み込みと起動時間増加を防ぐための変更です。

### Description
- `Accessor.load_startup_image_items` のシグネチャを `load_startup_image_items(self, model_id: ModelId)` に変更し、インターフェイスを更新しました (`app/application/accessor.py`)。
- `LocalAccessor.load_startup_image_items` を修正して、`glob`による全DB走査を廃止し、`meta_dir/{model_name}-{pretrained}/sqlite_image_meta.db` の単一ファイルだけを読み込むようにしました (`app/infrastructure/local_accessor.py`)。DB存在時の警告ログは具体的なパスを出力します。
- `DummyAccessor` のシグネチャ追従を行いました (`app/infrastructure/dummy_accessor.py`)。
- `Usecase.__init__` に `startup_model_id: ModelId` 引数を追加し、起動時にそのモデルIDを渡して起動用DBを読み込むように変更しました (`app/application/usecase.py`)。
- エントリーポイントの `app.py` で起動対象モデルを明示的に `startup_model_id = ModelId("ViT-L-14", "openai")` として `Usecase` に渡すようにしました。

### Testing
- `python -m compileall app app.py` を実行してコンパイルエラーがないことを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbda488914832496e28a9b6fccfdbd)