### PR TITLE
Load initial images by page and fetch ratings only for visible items

### DIFF
--- a/app/application/usecase.py
+++ b/app/application/usecase.py
@@ -121,11 +121,18 @@ class Usecase:
             "aesthetic_quality": 0.0,
         }
 
-    def get_rating_list(self, model_id: ModelId) -> dict[ImageId, str]:
-        """画像のrating一覧を取得する"""
+    def get_rating_list(
+        self, model_id: ModelId, image_ids: list[ImageId] | None = None
+    ) -> dict[ImageId, str]:
+        """指定された画像IDに限定してrating一覧を取得する"""
 
         _, items = self._get_index_and_items(model_id, "original")
-        return {item.id: item.rating for item in items}
+        target_ids = set(image_ids) if image_ids is not None else None
+        return {
+            item.id: item.rating
+            for item in items
+            if target_ids is None or item.id in target_ids
+        }
 
     # ===================================================================
 

--- a/app/presentation/controller.py
+++ b/app/presentation/controller.py
@@ -83,7 +83,7 @@ def resource(target: str):
 # ------------------------------------------------------------
 
 
-DEFAULT_IMAGE_ITEM_PAGE_SIZE = 10000
+DEFAULT_IMAGE_ITEM_PAGE_SIZE = 60
 
 
 @app.route("/image_item")
@@ -115,14 +115,34 @@ def get_image_metadata(model_name: str, pretrained: str, id: str):
     return json.dumps(usecase.get_image_metadata(model_id, ImageId(id)))
 
 
-@app.route("/image_ratings/<model_name>/<pretrained>")
+@app.route("/image_ratings/<model_name>/<pretrained>", methods=["GET", "POST"])
 def get_image_ratings(model_name: str, pretrained: str):
-    """画像のrating一覧を返す"""
+    """指定された画像IDに限定してrating一覧を返す"""
 
     model_id: ModelId = ModelId(model_name, pretrained)
-    ratings: dict[ImageId, str] = usecase.get_rating_list(model_id)
+    image_ids = get_requested_image_ids()
+    ratings: dict[ImageId, str] = usecase.get_rating_list(model_id, image_ids)
     rating_dict = {image_id.id: rating for image_id, rating in ratings.items()}
     return json.dumps(rating_dict)
+
+
+def get_requested_image_ids() -> list[ImageId] | None:
+    """rating取得リクエストから対象画像IDリストを取り出す"""
+
+    if request.method == "POST":
+        json_obj = request.get_json(silent=True) or {}
+        params = json_obj.get("params", {})
+        id_text_list = params.get("id") or params.get("ids")
+    else:
+        id_text_list = request.args.getlist("id") or request.args.getlist("ids")
+        if not id_text_list:
+            ids_text = request.args.get("ids")
+            id_text_list = ids_text.split(",") if ids_text else None
+
+    if id_text_list is None:
+        return None
+
+    return [ImageId(item_id) for item_id in id_text_list if item_id]
 
 
 @app.route("/image/<id>/small")

--- a/app/presentation/view/js/main.js
+++ b/app/presentation/view/js/main.js
@@ -18,6 +18,11 @@ const app = Vue.createApp({
     data() {
         return {
             load_size: 50,
+            pageSize: 0,
+            nextPage: 0,
+            hasMorePages: true,
+            isLoadingPage: false,
+            isPagedBrowseMode: true,
             message: "test",
             text: "",
             isShowSetting: false,
@@ -111,13 +116,12 @@ const app = Vue.createApp({
          */
         init() {
 
-            this.ensureRatingMap()
-            .then(this.initBuffer)
-            .then(this.initImage)
+            this.initBuffer()
+            .then(() => this.initImage())
         },
 
         onModelChange(){
-            this.ensureRatingMap()
+            this.ensureRatingMapForResults(this.rawResultBuffer)
             .then(() => {
                 this.applyRatingFilterToBuffer()
                 this.initImage()
@@ -130,6 +134,7 @@ const app = Vue.createApp({
         initImage() {
             this.selectedItemId = {}
             this.showedItemIndex = 0
+            this.padding_top = 0
 
             const end = this.numRows * this.numCols
             this.displayItems = this.resultBuffer.slice(0, end).map(result => ({
@@ -151,16 +156,42 @@ const app = Vue.createApp({
          */
         initBuffer() {
 
-            //画像項目をページ指定で取得する（デフォルトは最初の1万件）
-            return repository.getImageItemsByPage(0)
+            this.pageSize = this.numRows * this.numCols
+            this.nextPage = 0
+            this.hasMorePages = true
+            this.isPagedBrowseMode = true
+            this.rawResultBuffer = []
+            this.resultBuffer = []
+
+            return this.loadNextImagePage()
+        },
+
+        loadNextImagePage() {
+            if (!this.hasMorePages || this.isLoadingPage) {
+                return Promise.resolve()
+            }
+
+            this.isLoadingPage = true
+
+            return repository.getImageItemsByPage(this.nextPage, this.pageSize)
             .then(objs => {
+                this.hasMorePages = objs.length === this.pageSize
+                this.nextPage += 1
 
                 //バッファに登録
                 /**
                  * @type {repository.ResultItem[]}
                  */
-                this.rawResultBuffer = markRaw(objs.map(obj => ({ item: obj, score: 0 })))
+                const results = objs.map(obj => ({ item: obj, score: 0 }))
+                this.rawResultBuffer = markRaw(this.rawResultBuffer.concat(results))
+                return this.ensureRatingMapForResults(results)
+            })
+            .then(() => {
                 this.applyRatingFilterToBuffer()
+                this.refreshVisibleItems()
+            })
+            .finally(() => {
+                this.isLoadingPage = false
             })
         },
 
@@ -168,16 +199,24 @@ const app = Vue.createApp({
             return `${this.model_name}-${this.pretrained}`
         },
 
-        ensureRatingMap() {
-            const ratingKey = this.getRatingMapKey()
+        ensureRatingMapForResults(results) {
+            return this.ensureRatingMapForItemIds(results.map(result => result.item.id))
+        },
 
-            if(this.ratingMaps[ratingKey]) {
+        ensureRatingMapForItemIds(itemIds) {
+            const ratingKey = this.getRatingMapKey()
+            const ratingMap = this.ratingMaps[ratingKey] || {}
+            const uniqueItemIds = [...new Set(itemIds)]
+            const missingItemIds = uniqueItemIds.filter(itemId => ratingMap[itemId] === undefined)
+
+            if(missingItemIds.length === 0) {
+                this.ratingMaps[ratingKey] = ratingMap
                 return Promise.resolve()
             }
 
-            return repository.getImageRatings(this.model_name, this.pretrained)
+            return repository.getImageRatings(this.model_name, this.pretrained, missingItemIds)
             .then((ratings) => {
-                this.ratingMaps[ratingKey] = ratings
+                this.ratingMaps[ratingKey] = { ...ratingMap, ...ratings }
             })
         },
 
@@ -213,6 +252,8 @@ const app = Vue.createApp({
 
             console.log("スクロール: " + scrollY + " / " + (this.item_height * this.resultBuffer.length / this.numCols));
 
+            this.loadNextImagePageIfNeeded()
+
             while (scrollY - this.padding_top > this.item_height){
                 this.padding_top += this.item_height;
                 this.padding_bottom = (this.item_height * this.resultBuffer.length / this.numCols) - this.padding_top;
@@ -223,6 +264,19 @@ const app = Vue.createApp({
                 this.padding_bottom = (this.item_height * this.resultBuffer.length / this.numCols) - this.padding_top;
                 this.showPrevImg();
             }
+        },
+
+        loadNextImagePageIfNeeded() {
+            if (!this.isPagedBrowseMode) {
+                return
+            }
+
+            const visibleEnd = this.showedItemIndex + this.numRows * this.numCols
+            if (visibleEnd + this.load_size < this.resultBuffer.length) {
+                return
+            }
+
+            this.loadNextImagePage()
         },
 
 
@@ -268,6 +322,13 @@ const app = Vue.createApp({
             this.showedItemIndex = start
         },
 
+        refreshVisibleItems(){
+            const end = Math.min(this.showedItemIndex + this.numRows * this.numCols, this.resultBuffer.length)
+            this.displayItems = []
+            this.sliceShowImg(this.showedItemIndex, end)
+            this.padding_bottom = Math.max((this.item_height * this.resultBuffer.length / this.numCols) - this.padding_top, 0)
+        },
+
         sliceShowImg(start, end){
             const slice = this.resultBuffer.slice(start, end).map(result => ({
                 id: result.item.id,
@@ -289,9 +350,7 @@ const app = Vue.createApp({
          */
         setBuffer(promise) {
 
-            return this.ensureRatingMap()
-            .then(() => promise)
-            .then(result => {
+            return promise.then(result => {
                 const clientStart = performance.now()
 
                 let array = result.list
@@ -310,8 +369,12 @@ const app = Vue.createApp({
                 //バッファに登録
                 this.search_query = result.search_query
                 this.rawResultBuffer = markRaw(array)
-                this.applyRatingFilterToBuffer()
-                this.clientDurationMs = performance.now() - clientStart
+                this.isPagedBrowseMode = false
+                return this.ensureRatingMapForResults(array)
+                .then(() => {
+                    this.applyRatingFilterToBuffer()
+                    this.clientDurationMs = performance.now() - clientStart
+                })
             })
         },
 
@@ -322,9 +385,7 @@ const app = Vue.createApp({
          * @return {Promise<void>}
          */
         runSearch(promise, afterBuffer = null) {
-            return this.ensureRatingMap()
-            .then(() => promise)
-            .then(result => {
+            return promise.then(result => {
                 // ── 計測開始：fetch は完了している
                 const clientStart = performance.now()
 
@@ -339,21 +400,25 @@ const app = Vue.createApp({
                 // バッファ更新
                 this.search_query = result.search_query
                 this.rawResultBuffer = markRaw(array)
-                this.applyRatingFilterToBuffer()
-
-                if (afterBuffer) afterBuffer()
-
-                // displayItems を更新（ここで Vue が patch を予約する）
-                this.initImage()
-
-                // ── Vue の DOM patch 完了を待つ
-                return nextTick()
-                // ── さらにブラウザのレイアウト・ペイント完了まで待つ
-                .then(() => new Promise(resolve => {
-                    requestAnimationFrame(() => requestAnimationFrame(resolve))
-                }))
+                this.isPagedBrowseMode = false
+                return this.ensureRatingMapForResults(array)
                 .then(() => {
-                    this.clientDurationMs = performance.now() - clientStart
+                    this.applyRatingFilterToBuffer()
+
+                    if (afterBuffer) afterBuffer()
+
+                    // displayItems を更新（ここで Vue が patch を予約する）
+                    this.initImage()
+
+                    // ── Vue の DOM patch 完了を待つ
+                    return nextTick()
+                    // ── さらにブラウザのレイアウト・ペイント完了まで待つ
+                    .then(() => new Promise(resolve => {
+                        requestAnimationFrame(() => requestAnimationFrame(resolve))
+                    }))
+                    .then(() => {
+                        this.clientDurationMs = performance.now() - clientStart
+                    })
                 })
             })
             .finally(() => { this.isSearching = false })

--- a/app/presentation/view/js/modules/repository.js
+++ b/app/presentation/view/js/modules/repository.js
@@ -32,11 +32,11 @@ export function getImageOriginalUrl(itemId) {
  * ページ指定で画像項目の一覧を取得する
  *
  * @param {number} page 0始まりのページ番号
- * @param {number} pageSize 取得する件数（デフォルトは1万件）
+ * @param {number} pageSize 取得する件数（デフォルトは初期表示分）
  *
  * @return {Promise<ImageItem[]>}
  */
-export async function getImageItemsByPage(page = 0, pageSize = 10000) {
+export async function getImageItemsByPage(page = 0, pageSize = 60) {
 
     return axios.get(`/image_item`, { params: { page: page, size: pageSize } }).then(res => res.data)
 }
@@ -58,9 +58,19 @@ export async function getImageMetadata(modelName, pretrained, itemId) {
     return axios.get(`/image_meta/${modelName}/${pretrained}/${itemId}`).then(res => res.data)
 }
 
-export async function getImageRatings(modelName, pretrained) {
+export async function getImageRatings(modelName, pretrained, itemIds = []) {
 
-    return axios.get(`/image_ratings/${modelName}/${pretrained}`).then(res => res.data)
+    if(itemIds.length === 0) {
+        return Promise.resolve({})
+    }
+
+    const payload = {
+        params:{
+            id: itemIds
+        }
+    }
+
+    return axios.post(`/image_ratings/${modelName}/${pretrained}`, payload).then(res => res.data)
 }
 
 


### PR DESCRIPTION
### Motivation
- Avoid fetching a huge default of image items (`10000`) and reduce frontend/server load by requesting only the initial visible grid and additional pages on scroll.
- Avoid fetching ratings for all images up-front and instead request ratings only for the currently loaded or searched item IDs to cut unnecessary work and network traffic.

### Description
- Changed the default page size used by the frontend `getImageItemsByPage` from `10000` to `60` and made the frontend request image pages incrementally by adding `pageSize`, `nextPage`, `hasMorePages`, and `isLoadingPage` state and `loadNextImagePage`/`loadNextImagePageIfNeeded` logic in `app/presentation/view/js/main.js`.
- Switched initial buffer loading to fetch only the first page (`initBuffer` → `loadNextImagePage`) and append subsequent pages on scroll, and added `isPagedBrowseMode` to distinguish paged browsing from search-mode.
- Added rating-fetch-by-ids support: `getImageRatings` in `app/presentation/view/js/modules/repository.js` now accepts an `itemIds` array and performs a `POST` requesting only those ids (returns `{}` for empty list), and `main.js` implements `ensureRatingMapForItemIds` to fetch only missing ratings for loaded items or search results.
- Backend support: set `DEFAULT_IMAGE_ITEM_PAGE_SIZE = 60` in `app/presentation/controller.py`, added `GET/POST` handling for `/image_ratings/<model_name>/<pretrained>` plus helper `get_requested_image_ids()` to parse requested ids, and updated `Usecase.get_rating_list` to accept an optional `image_ids` filter and return ratings only for requested ids in `app/application/usecase.py`.

### Testing
- Ran `node --check app/presentation/view/js/main.js` and `node --check app/presentation/view/js/modules/repository.js`, which succeeded.
- Ran `python -m py_compile app/presentation/controller.py app/application/usecase.py`, which succeeded (syntax checks passed).
- Ran `pytest -q`, which failed during collection due to the environment missing `numpy` (test environment issue, not related to this change).
- Ran `uv run pytest -q`, which failed dependency resolution because `onnxruntime-gpu==1.23.2` has no wheel for the current CPython 3.14 platform.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a43baf8e4832490a94f763953cf84)