### PR TITLE
Move search result sorting server-side and add `result_size` API/UI

### DIFF
--- a/app/application/usecase.py
+++ b/app/application/usecase.py
@@ -68,6 +68,43 @@ class Usecase:
 
         return self._accessor.load_index_with_metadata(model_id, aesthetic_model_name)
 
+    def _normalize_result_size(self, result_size: int | None) -> int:
+        """検索結果件数の上限を安全な正整数に正規化する。"""
+
+        try:
+            if result_size is None:
+                return 2048
+
+            return max(1, int(result_size))
+        except (TypeError, ValueError):
+            return 2048
+
+    def _sort_result_items(
+        self, scores: list[ResultImageItem]
+    ) -> list[ResultImageItem]:
+        """検索結果をスコア降順、同点時は名前昇順で整列する。"""
+
+        return sorted(
+            scores,
+            key=lambda result: (
+                -float(result.score.score),
+                result.item.display_name.name,
+            ),
+        )
+
+    def _finalize_result(
+        self,
+        scores: list[ResultImageItem],
+        search_query: str,
+        result_size: int | None,
+    ) -> ResultImageItemList:
+        """JSON変換前の検索結果を整列し、指定件数に切り詰める。"""
+
+        normalized_result_size = self._normalize_result_size(result_size)
+        return ResultImageItemList(
+            self._sort_result_items(scores)[:normalized_result_size], search_query
+        )
+
     # ===================================================================
 
     def get_all_image_item(self) -> list[ImageItem]:
@@ -287,6 +324,7 @@ class Usecase:
         aesthetic_quality_range_min: float,
         aesthetic_quality_range_max: float,
         aesthetic_model_name: str,
+        result_size: int | None = None,
     ) -> ResultImageItemList:
         """文字列から検索する"""
 
@@ -310,6 +348,7 @@ class Usecase:
         scores: list[ResultImageItem] = self.similarity_eval(
             item_list=item_list,
             index=index,
+            result_size=self._normalize_result_size(result_size),
             query_features=features,
             mean_centering=True,
             mean_vector=self._accessor.get_mean_meta_vector(model_id),
@@ -323,7 +362,7 @@ class Usecase:
             aesthetic_quality_range_max,
             aesthetic_model_name,
         )
-        return ResultImageItemList(scores, self.format_search_query(features.copy()))
+        return self._finalize_result(scores, self.format_search_query(features.copy()), result_size)
 
     def search_image(
         self,
@@ -333,6 +372,7 @@ class Usecase:
         aesthetic_quality_range_min: float,
         aesthetic_quality_range_max: float,
         aesthetic_model_name: str,
+        result_size: int | None = None,
     ) -> ResultImageItemList:
         """画像から検索する"""
 
@@ -363,6 +403,7 @@ class Usecase:
         scores: list[ResultImageItem] = self.similarity_eval(
             item_list=item_list,
             index=index,
+            result_size=self._normalize_result_size(result_size),
             query_features=features,
             mean_centering=True,
             mean_vector=self._accessor.get_mean_meta_vector(model_id),
@@ -376,7 +417,7 @@ class Usecase:
             aesthetic_quality_range_max,
             aesthetic_model_name,
         )
-        return ResultImageItemList(scores, self.format_search_query(features))
+        return self._finalize_result(scores, self.format_search_query(features), result_size)
 
     def search_name(
         self,
@@ -387,6 +428,7 @@ class Usecase:
         aesthetic_quality_range_min: float,
         aesthetic_quality_range_max: float,
         aesthetic_model_name: str,
+        result_size: int | None = None,
     ) -> ResultImageItemList:
         """文字列から名前検索する"""
 
@@ -412,10 +454,10 @@ class Usecase:
             aesthetic_quality_range_max,
             aesthetic_model_name,
         )
-        return ResultImageItemList(scores, "")
+        return self._finalize_result(scores, "", result_size)
 
     def search_upload_image(
-        self, model_id: ModelId, image: UploadImage
+        self, model_id: ModelId, image: UploadImage, result_size: int | None = None
     ) -> ResultImageItemList:
         """アップロードされた画像から検索する"""
 
@@ -439,12 +481,13 @@ class Usecase:
         scores: list[ResultImageItem] = self.similarity_eval(
             item_list=item_list,
             index=index,
+            result_size=self._normalize_result_size(result_size),
             query_features=features,
             mean_centering=True,
             mean_vector=self._accessor.get_mean_meta_vector(model_id),
         )
 
-        return ResultImageItemList(scores, self.format_search_query(features))
+        return self._finalize_result(scores, self.format_search_query(features), result_size)
 
     def search_random(
         self,
@@ -453,6 +496,7 @@ class Usecase:
         aesthetic_quality_range_min: float,
         aesthetic_quality_range_max: float,
         aesthetic_model_name: str,
+        result_size: int | None = None,
     ) -> ResultImageItemList:
         """乱数から検索する"""
 
@@ -467,6 +511,7 @@ class Usecase:
         scores: list[ResultImageItem] = self.similarity_eval(
             item_list=item_list,
             index=index,
+            result_size=self._normalize_result_size(result_size),
             query_features=features,
             mean_centering=True,
             mean_vector=self._accessor.get_mean_meta_vector(model_id),
@@ -479,7 +524,7 @@ class Usecase:
             aesthetic_quality_range_max,
             aesthetic_model_name,
         )
-        return ResultImageItemList(scores, self.format_search_query(features))
+        return self._finalize_result(scores, self.format_search_query(features), result_size)
 
     def search_query(
         self,
@@ -489,6 +534,7 @@ class Usecase:
         aesthetic_quality_range_min: float,
         aesthetic_quality_range_max: float,
         aesthetic_model_name: str,
+        result_size: int | None = None,
     ) -> ResultImageItemList:
         """クエリから検索する"""
 
@@ -501,6 +547,7 @@ class Usecase:
         scores: list[ResultImageItem] = self.similarity_eval(
             item_list=item_list,
             index=index,
+            result_size=self._normalize_result_size(result_size),
             query_features=features,
             mean_centering=True,
             mean_vector=self._accessor.get_mean_meta_vector(model_id),
@@ -514,7 +561,7 @@ class Usecase:
             aesthetic_quality_range_max,
             aesthetic_model_name,
         )
-        return ResultImageItemList(scores, self.format_search_query(features))
+        return self._finalize_result(scores, self.format_search_query(features), result_size)
 
     def add_text_features(
         self,
@@ -526,6 +573,7 @@ class Usecase:
         aesthetic_quality_range_min: float,
         aesthetic_quality_range_max: float,
         aesthetic_model_name: str,
+        result_size: int | None = None,
     ) -> ResultImageItemList:
         """クエリにstrengthの強さ分テキストの特徴を足してから検索する"""
 
@@ -556,6 +604,7 @@ class Usecase:
         scores: list[ResultImageItem] = self.similarity_eval(
             item_list=item_list,
             index=index,
+            result_size=self._normalize_result_size(result_size),
             query_features=features,
             mean_centering=True,
             mean_vector=self._accessor.get_mean_meta_vector(model_id),
@@ -569,7 +618,7 @@ class Usecase:
             aesthetic_quality_range_max,
             aesthetic_model_name
         )
-        return ResultImageItemList(scores, self.format_search_query(features))
+        return self._finalize_result(scores, self.format_search_query(features), result_size)
 
 
     def search_tags(
@@ -581,6 +630,7 @@ class Usecase:
         aesthetic_quality_range_min: float,
         aesthetic_quality_range_max: float,
         aesthetic_model_name: str,
+        result_size: int | None = None,
     ) -> ResultImageItemList:
         """文字列からタグ検索する"""
 
@@ -606,7 +656,7 @@ class Usecase:
             aesthetic_quality_range_max,
             aesthetic_model_name,
         )
-        return ResultImageItemList(scores, "")
+        return self._finalize_result(scores, "", result_size)
 
     def search_style_cluster(
         self,
@@ -617,6 +667,7 @@ class Usecase:
         aesthetic_quality_range_min: float,
         aesthetic_quality_range_max: float,
         aesthetic_model_name: str,
+        result_size: int | None = None,
     ) -> ResultImageItemList:
         """style_cluster を文字列検索する"""
 
@@ -642,7 +693,7 @@ class Usecase:
             aesthetic_quality_range_max,
             aesthetic_model_name,
         )
-        return ResultImageItemList(scores, "")
+        return self._finalize_result(scores, "", result_size)
 
     def get_images_zip(self, id_list):
         """指定された画像IDからZIPバッファを生成する。

--- a/app/presentation/controller.py
+++ b/app/presentation/controller.py
@@ -23,6 +23,18 @@ usecase: Usecase = None
 logger = logging.getLogger(__name__)
 
 
+def get_result_size(params: dict | None, default: int = 2048) -> int:
+    """APIリクエストから検索結果件数の上限を取得する。"""
+
+    if params is None:
+        return default
+
+    try:
+        return max(1, int(params.get("result_size", default)))
+    except (TypeError, ValueError):
+        return default
+
+
 def start_app(in_usecase: Usecase):
     """エントリーポイント"""
 
@@ -186,7 +198,8 @@ def search_text():
         aesthetic_quality_range,
         aesthetic_model_name,
     )
-    result = usecase.search_text(model_id, UploadText(text), aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name)
+    result_size = get_result_size(args)
+    result = usecase.search_text(model_id, UploadText(text), aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name, result_size)
     return from_result_to_json(result)
 
 
@@ -210,7 +223,8 @@ def search_image():
     # IDのリストを取得する。
     id_text_list: list[str] = json_obj["id"]
     id_list: list[ImageId] = list(map(ImageId, id_text_list))
-    result = usecase.search_image(model_id, id_list, aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name)
+    result_size = get_result_size(json_obj)
+    result = usecase.search_image(model_id, id_list, aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name, result_size)
     return from_result_to_json(result)
 
 
@@ -235,7 +249,8 @@ def search_name():
         aesthetic_quality_range,
         aesthetic_model_name,
     )
-    result = usecase.search_name(model_id, UploadText(text), is_regexp, aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name)
+    result_size = get_result_size(args)
+    result = usecase.search_name(model_id, UploadText(text), is_regexp, aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name, result_size)
     return from_result_to_json(result)
 
 
@@ -255,7 +270,8 @@ def search_upload_image():
     binary = base64.b64decode(base64_text)
     image: UploadImage = UploadImage(binary, content_type)
 
-    result = usecase.search_upload_image(model_id, image)
+    result_size = get_result_size(json_obj)
+    result = usecase.search_upload_image(model_id, image, result_size)
     return from_result_to_json(result)
 
 
@@ -277,7 +293,8 @@ def search_random():
     aesthetic_model_name = json_obj["aesthetic_model_name"]
 
     # IDのリストを取得する。
-    result = usecase.search_random(model_id, aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name)
+    result_size = get_result_size(json_obj)
+    result = usecase.search_random(model_id, aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name, result_size)
     return from_result_to_json(result)
 
 
@@ -301,7 +318,8 @@ def search_query():
     aesthetic_model_name = json_obj["aesthetic_model_name"]
 
     # IDのリストを取得する。
-    result = usecase.search_query(model_id, search_query, aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name)
+    result_size = get_result_size(json_obj)
+    result = usecase.search_query(model_id, search_query, aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name, result_size)
     return from_result_to_json(result)
 
 
@@ -329,7 +347,8 @@ def add_text_features():
     aesthetic_model_name = json_obj["aesthetic_model_name"]
 
     # IDのリストを取得する。
-    result = usecase.add_text_features(model_id, UploadText(text), search_query, strength, aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name)
+    result_size = get_result_size(json_obj)
+    result = usecase.add_text_features(model_id, UploadText(text), search_query, strength, aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name, result_size)
     return from_result_to_json(result)
 
 
@@ -354,7 +373,8 @@ def search_tags():
     aesthetic_model_name = json_obj["aesthetic_model_name"]
 
     # IDのリストを取得する。
-    result = usecase.search_tags(model_id, UploadText(text), is_regexp, aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name)
+    result_size = get_result_size(json_obj)
+    result = usecase.search_tags(model_id, UploadText(text), is_regexp, aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name, result_size)
     return from_result_to_json(result)
 
 
@@ -375,7 +395,8 @@ def search_style_cluster():
 
     aesthetic_model_name = json_obj["aesthetic_model_name"]
 
-    result = usecase.search_style_cluster(model_id, UploadText(text), is_regexp, aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name)
+    result_size = get_result_size(json_obj)
+    result = usecase.search_style_cluster(model_id, UploadText(text), is_regexp, aesthetic_quality_beta, aesthetic_quality_range[0], aesthetic_quality_range[1], aesthetic_model_name, result_size)
     return from_result_to_json(result)
 
 @app.route("/download_images_zip", methods=["POST"])

--- a/app/presentation/view/index.html
+++ b/app/presentation/view/index.html
@@ -77,6 +77,14 @@
                                 v-model="features_strength"
                                 thumb-label
                                 ></v-slider>
+                            <v-text-field
+                            v-model.number="resultSize"
+                            label="result size"
+                            type="number"
+                            min="1"
+                            hint="検索結果の最大件数（モバイルでは小さめ推奨）"
+                            persistent-hint
+                            ></v-text-field>
                             <v-autocomplete
                             v-model="model_name"
                             label="model_name"

--- a/app/presentation/view/js/main.js
+++ b/app/presentation/view/js/main.js
@@ -1,9 +1,7 @@
-import natsort from 'https://cdn.jsdelivr.net/npm/natsort@2.0.3/+esm'
 import jszip from 'https://cdn.jsdelivr.net/npm/jszip@3.10.1/+esm'
 
 
 import * as repository from "./modules/repository.js"
-import * as util from "./util.js"
 
 const { markRaw, nextTick } = Vue
 
@@ -29,6 +27,7 @@ const app = Vue.createApp({
             isRegexp: false,
             numCols: 6,
             numRows: 10,
+            resultSize: 2048,
             model_name: "ViT-L-14",
             pretrained: "openai",
             search_query: "",
@@ -357,14 +356,7 @@ const app = Vue.createApp({
                 // console.log('結果', result)
                 // console.log('ソート前' + JSON.stringify(array))
 
-                //並び替え
-                const nsCmp = natsort.default()
-                array = array.sort(util.cancatComparator(
-                    (a, b) => b.score - a.score,
-                    (a, b) => nsCmp(a.item.name, b.item.name)
-                ))
-
-                // console.log('ソート後' + JSON.stringify(array))
+                // サーバ側でスコア降順・名前昇順に整列済み
 
                 //バッファに登録
                 this.search_query = result.search_query
@@ -389,13 +381,8 @@ const app = Vue.createApp({
                 // ── 計測開始：fetch は完了している
                 const clientStart = performance.now()
 
-                // ソート
+                // サーバ側でスコア降順・名前昇順に整列済み
                 const array = result.list
-                const nsCmp = natsort.default()
-                array.sort(util.cancatComparator(
-                    (a, b) => b.score - a.score,
-                    (a, b) => nsCmp(a.item.name, b.item.name)
-                ))
 
                 // バッファ更新
                 this.search_query = result.search_query
@@ -430,7 +417,7 @@ const app = Vue.createApp({
         textSearchButton() {
             const searchStart = performance.now()
             this.isSearching = true
-            const searchPromise = repository.searchText(this.model_name, this.pretrained, this.text, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name)
+            const searchPromise = repository.searchText(this.model_name, this.pretrained, this.text, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name, this.resultSize)
             .then(result => {
                 this.searchDurationMs = performance.now() - searchStart
                 return result
@@ -446,7 +433,7 @@ const app = Vue.createApp({
 
             let selectedId = Object.keys(this.selectedItemId)
 
-            const searchPromise = repository.searchImage(this.model_name, this.pretrained, selectedId, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name)
+            const searchPromise = repository.searchImage(this.model_name, this.pretrained, selectedId, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name, this.resultSize)
             .then(result => {
                 this.searchDurationMs = performance.now() - searchStart
                 return result
@@ -462,7 +449,7 @@ const app = Vue.createApp({
             }
             const searchStart = performance.now()
             this.isSearching = true
-            const searchPromise = repository.searchUploadImage(this.model_name, this.pretrained, this.uploadFile)
+            const searchPromise = repository.searchUploadImage(this.model_name, this.pretrained, this.uploadFile, this.resultSize)
             .then(result => {
                 this.searchDurationMs = performance.now() - searchStart
                 return result
@@ -475,7 +462,7 @@ const app = Vue.createApp({
         nameSearchButton() {
             const searchStart = performance.now()
             this.isSearching = true
-            const searchPromise = repository.searchName(this.model_name, this.pretrained, this.text, this.isRegexp, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name)
+            const searchPromise = repository.searchName(this.model_name, this.pretrained, this.text, this.isRegexp, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name, this.resultSize)
             .then(result => {
                 this.searchDurationMs = performance.now() - searchStart
                 return result
@@ -510,7 +497,7 @@ const app = Vue.createApp({
         randomSearchButton() {
             const searchStart = performance.now()
             this.isSearching = true
-            const searchPromise = repository.searchRandom(this.model_name, this.pretrained, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name)
+            const searchPromise = repository.searchRandom(this.model_name, this.pretrained, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name, this.resultSize)
             .then(result => {
                 this.searchDurationMs = performance.now() - searchStart
                 return result
@@ -523,7 +510,7 @@ const app = Vue.createApp({
         querySearchButton() {
             const searchStart = performance.now()
             this.isSearching = true
-            const searchPromise = repository.searchQuery(this.model_name, this.pretrained, this.search_query, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name)
+            const searchPromise = repository.searchQuery(this.model_name, this.pretrained, this.search_query, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name, this.resultSize)
             .then(result => {
                 this.searchDurationMs = performance.now() - searchStart
                 return result
@@ -536,7 +523,7 @@ const app = Vue.createApp({
         addTextFeaturesButton() {
             const searchStart = performance.now()
             this.isSearching = true
-            const searchPromise = repository.addTextFeatures(this.model_name, this.pretrained, this.text, this.search_query, this.features_strength, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name)
+            const searchPromise = repository.addTextFeatures(this.model_name, this.pretrained, this.text, this.search_query, this.features_strength, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name, this.resultSize)
             .then(result => {
                 this.searchDurationMs = performance.now() - searchStart
                 return result
@@ -549,7 +536,7 @@ const app = Vue.createApp({
         tagSearchButton() {
             const searchStart = performance.now()
             this.isSearching = true
-            const searchPromise = repository.searchTags(this.model_name, this.pretrained, this.text, this.isRegexp, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name)
+            const searchPromise = repository.searchTags(this.model_name, this.pretrained, this.text, this.isRegexp, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name, this.resultSize)
             .then(result => {
                 this.searchDurationMs = performance.now() - searchStart
                 return result
@@ -562,7 +549,7 @@ const app = Vue.createApp({
         styleClusterSearchButton() {
             const searchStart = performance.now()
             this.isSearching = true
-            const searchPromise = repository.searchStyleCluster(this.model_name, this.pretrained, this.text, this.isRegexp, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name)
+            const searchPromise = repository.searchStyleCluster(this.model_name, this.pretrained, this.text, this.isRegexp, this.aesthetic_quality_beta, this.aesthetic_quality_range, this.aesthetic_model_name, this.resultSize)
             .then(result => {
                 this.searchDurationMs = performance.now() - searchStart
                 return result

--- a/app/presentation/view/js/modules/repository.js
+++ b/app/presentation/view/js/modules/repository.js
@@ -11,6 +11,13 @@ import { fileToBase64 } from "./util.js"
  * @typedef {{item:ImageItem, score:number}} ResultItem
  */
 
+const DEFAULT_RESULT_SIZE = 2048
+
+function normalizeResultSize(resultSize) {
+    const normalized = Number.parseInt(resultSize, 10)
+    return Number.isFinite(normalized) && normalized > 0 ? normalized : DEFAULT_RESULT_SIZE
+}
+
 
 /**
  * 画像項目のIDから画像のURLを取得する
@@ -84,7 +91,7 @@ export async function getImageRatings(modelName, pretrained, itemIds = []) {
  * 
  * @return {Promise<ResultItem[]>}
  */
-export async function searchText(modelName, pretrained, text, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name) {
+export async function searchText(modelName, pretrained, text, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name, resultSize = DEFAULT_RESULT_SIZE) {
 
     let payload = {
 
@@ -94,7 +101,8 @@ export async function searchText(modelName, pretrained, text, aesthetic_quality_
             text : text,
             aesthetic_quality_beta: aesthetic_quality_beta,
             aesthetic_quality_range: aesthetic_quality_range,
-            aesthetic_model_name: aesthetic_model_name
+            aesthetic_model_name: aesthetic_model_name,
+            result_size: normalizeResultSize(resultSize)
         }
     }
 
@@ -111,7 +119,7 @@ export async function searchText(modelName, pretrained, text, aesthetic_quality_
  * 
  * @return {Promise<ResultItem[]>}
  */
-export async function searchImage(modelName, pretrained, itemId_list, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name) {
+export async function searchImage(modelName, pretrained, itemId_list, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name, resultSize = DEFAULT_RESULT_SIZE) {
 
     let payload = {
 
@@ -121,7 +129,8 @@ export async function searchImage(modelName, pretrained, itemId_list, aesthetic_
             id : itemId_list,
             aesthetic_quality_beta: aesthetic_quality_beta,
             aesthetic_quality_range: aesthetic_quality_range,
-            aesthetic_model_name: aesthetic_model_name
+            aesthetic_model_name: aesthetic_model_name,
+            result_size: normalizeResultSize(resultSize)
         }
     }
 
@@ -137,7 +146,7 @@ export async function searchImage(modelName, pretrained, itemId_list, aesthetic_
  *
  * @return {Promise<ResultItem[]>}
  */
-export async function searchName(modelName, pretrained, itemId_list, is_regexp, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name) {
+export async function searchName(modelName, pretrained, itemId_list, is_regexp, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name, resultSize = DEFAULT_RESULT_SIZE) {
 
     let payload = {
 
@@ -148,7 +157,8 @@ export async function searchName(modelName, pretrained, itemId_list, is_regexp, 
             is_regexp : is_regexp.toString(),
             aesthetic_quality_beta: aesthetic_quality_beta,
             aesthetic_quality_range: aesthetic_quality_range,
-            aesthetic_model_name: aesthetic_model_name
+            aesthetic_model_name: aesthetic_model_name,
+            result_size: normalizeResultSize(resultSize)
         }
     }
 
@@ -165,7 +175,7 @@ export async function searchName(modelName, pretrained, itemId_list, is_regexp, 
  * 
  * @return {Promise<ResultItem[]>}
  */
-export async function searchRandom(modelName, pretrained, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name) {
+export async function searchRandom(modelName, pretrained, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name, resultSize = DEFAULT_RESULT_SIZE) {
 
     let payload = {
 
@@ -174,7 +184,8 @@ export async function searchRandom(modelName, pretrained, aesthetic_quality_beta
             pretrained: pretrained,
             aesthetic_quality_beta: aesthetic_quality_beta,
             aesthetic_quality_range: aesthetic_quality_range,
-            aesthetic_model_name: aesthetic_model_name
+            aesthetic_model_name: aesthetic_model_name,
+            result_size: normalizeResultSize(resultSize)
         }
     }
 
@@ -191,7 +202,7 @@ export async function searchRandom(modelName, pretrained, aesthetic_quality_beta
  * 
  * @return {Promise<ResultItem[]>}
  */
-export async function searchQuery(modelName, pretrained, search_query, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name) {
+export async function searchQuery(modelName, pretrained, search_query, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name, resultSize = DEFAULT_RESULT_SIZE) {
 
     let payload = {
 
@@ -201,7 +212,8 @@ export async function searchQuery(modelName, pretrained, search_query, aesthetic
             search_query: search_query,
             aesthetic_quality_beta: aesthetic_quality_beta,
             aesthetic_quality_range: aesthetic_quality_range,
-            aesthetic_model_name: aesthetic_model_name
+            aesthetic_model_name: aesthetic_model_name,
+            result_size: normalizeResultSize(resultSize)
         }
     }
 
@@ -217,7 +229,7 @@ export async function searchQuery(modelName, pretrained, search_query, aesthetic
  * 
  * @return {Promise<ResultItem[]>}
  */
-export async function addTextFeatures(modelName, pretrained, text, search_query, features_strength, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name) {
+export async function addTextFeatures(modelName, pretrained, text, search_query, features_strength, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name, resultSize = DEFAULT_RESULT_SIZE) {
 
     let payload = {
 
@@ -229,7 +241,8 @@ export async function addTextFeatures(modelName, pretrained, text, search_query,
             features_strength: features_strength,
             aesthetic_quality_beta: aesthetic_quality_beta,
             aesthetic_quality_range: aesthetic_quality_range,
-            aesthetic_model_name: aesthetic_model_name
+            aesthetic_model_name: aesthetic_model_name,
+            result_size: normalizeResultSize(resultSize)
         }
     }
 
@@ -245,7 +258,7 @@ export async function addTextFeatures(modelName, pretrained, text, search_query,
  * 
  * @return {Promise<ResultItem[]>}
  */
-export async function searchTags(modelName, pretrained, itemId_list, is_regexp, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name) {
+export async function searchTags(modelName, pretrained, itemId_list, is_regexp, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name, resultSize = DEFAULT_RESULT_SIZE) {
 
     let payload = {
 
@@ -256,7 +269,8 @@ export async function searchTags(modelName, pretrained, itemId_list, is_regexp, 
             is_regexp : is_regexp.toString(),
             aesthetic_quality_beta: aesthetic_quality_beta,
             aesthetic_quality_range: aesthetic_quality_range,
-            aesthetic_model_name: aesthetic_model_name
+            aesthetic_model_name: aesthetic_model_name,
+            result_size: normalizeResultSize(resultSize)
         }
     }
 
@@ -273,7 +287,7 @@ export async function searchTags(modelName, pretrained, itemId_list, is_regexp, 
  *
  * @return {Promise<ResultItem[]>}
  */
-export async function searchStyleCluster(modelName, pretrained, itemId_list, is_regexp, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name) {
+export async function searchStyleCluster(modelName, pretrained, itemId_list, is_regexp, aesthetic_quality_beta, aesthetic_quality_range, aesthetic_model_name, resultSize = DEFAULT_RESULT_SIZE) {
 
     let payload = {
 
@@ -284,7 +298,8 @@ export async function searchStyleCluster(modelName, pretrained, itemId_list, is_
             is_regexp : is_regexp.toString(),
             aesthetic_quality_beta: aesthetic_quality_beta,
             aesthetic_quality_range: aesthetic_quality_range,
-            aesthetic_model_name: aesthetic_model_name
+            aesthetic_model_name: aesthetic_model_name,
+            result_size: normalizeResultSize(resultSize)
         }
     }
 
@@ -299,14 +314,15 @@ export async function searchStyleCluster(modelName, pretrained, itemId_list, is_
  * @param {File} file
  * @returns {Promise<ResultItem[]>}
  */
-export async function searchUploadImage(modelName, pretrained, file) {
+export async function searchUploadImage(modelName, pretrained, file, resultSize = DEFAULT_RESULT_SIZE) {
     const dataUrl = await fileToBase64(file)
     let payload = {
         params:{
             model_name: modelName,
             pretrained: pretrained,
             base64: dataUrl.split(',')[1],
-            content_type: file.type
+            content_type: file.type,
+            result_size: normalizeResultSize(resultSize)
         }
     }
     return axios.post("/search/uploadimage", payload).then(res => res.data)

--- a/tests/test_usecase_result_sorting.py
+++ b/tests/test_usecase_result_sorting.py
@@ -1,0 +1,64 @@
+import sys
+import types
+import unittest
+
+# The result-finalization helpers under test do not need native ML/image deps.
+# Some CI/dev shells used for lightweight tests do not install them, so provide
+# import-time stubs only when the real modules are absent.
+numpy_stub = types.ModuleType("numpy")
+numpy_stub.ndarray = object
+sys.modules.setdefault("numpy", numpy_stub)
+sys.modules.setdefault("faiss", types.ModuleType("faiss"))
+sys.modules.setdefault("tqdm", types.ModuleType("tqdm"))
+if "PIL" not in sys.modules:
+    pil_module = types.ModuleType("PIL")
+    pil_image_module = types.ModuleType("PIL.Image")
+    pil_module.Image = pil_image_module
+    sys.modules["PIL"] = pil_module
+    sys.modules["PIL.Image"] = pil_image_module
+
+from app.application.usecase import Usecase
+from app.domain.domain_object import (
+    ImageId,
+    ImageItem,
+    ImageName,
+    ResultImageItem,
+    Score,
+)
+
+
+def make_result(name: str, score: float) -> ResultImageItem:
+    return ResultImageItem(
+        ImageItem(ImageId(name), ImageName(name)),
+        Score(score),
+    )
+
+
+class UsecaseResultSortingTests(unittest.TestCase):
+    def setUp(self):
+        self.usecase = Usecase.__new__(Usecase)
+
+    def test_finalize_result_sorts_score_desc_then_name_asc_and_limits(self):
+        results = [
+            make_result("image10.png", 0.5),
+            make_result("image02.png", 0.9),
+            make_result("image01.png", 0.9),
+            make_result("image00.png", 0.1),
+        ]
+
+        finalized = self.usecase._finalize_result(results, "query", 3)
+
+        self.assertEqual(
+            [result.item.display_name.name for result in finalized.list],
+            ["image01.png", "image02.png", "image10.png"],
+        )
+        self.assertEqual(finalized.search_query, "query")
+
+    def test_normalize_result_size_falls_back_to_default(self):
+        self.assertEqual(self.usecase._normalize_result_size(None), 2048)
+        self.assertEqual(self.usecase._normalize_result_size("invalid"), 2048)
+        self.assertEqual(self.usecase._normalize_result_size(0), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Reduce heavy client-side full-list sorting and ensure deterministic ordering by performing score-desc / name-asc sorting on the server prior to JSON serialization.  
- Allow clients (especially mobile) to control the number of returned results via a `result_size` parameter so UI can request fewer items and avoid unnecessary transfer and processing.

### Description

- Add helpers in `app/application/usecase.py`: `_normalize_result_size`, `_sort_result_items`, and `_finalize_result`, and propagate a `result_size` parameter through search methods to apply FAISS `k` limits and final trimming.  
- Add `get_result_size` in `app/presentation/controller.py` and pass the parsed `result_size` from each search endpoint into the usecase.  
- Update the frontend: add `resultSize` UI field in `app/presentation/view/index.html`, add client-side `DEFAULT_RESULT_SIZE` and `normalizeResultSize` in `app/presentation/view/js/modules/repository.js`, propagate `resultSize` from `app/presentation/view/js/main.js` into repository calls, and remove the previous client-side full-list sorting (`natsort` + `util.cancatComparator`) so server-sorted results are used directly.  
- Add unit test `tests/test_usecase_result_sorting.py` to validate the server-side finalization logic (sorting and limit normalization).

### Testing

- Ran `python -m unittest tests.test_usecase_result_sorting` and the new test passed (OK).  
- Ran `python -m compileall app tests` which succeeded.  
- Ran `node --check` on `app/presentation/view/js/main.js` and `app/presentation/view/js/modules/repository.js` which succeeded.  
- Full test discovery (`python -m unittest discover tests`) is blocked in this environment because existing `tests/test_tagger.py` requires `numpy` which is not installed here, and `uv run` for broader test runs cannot install `onnxruntime-gpu==1.23.2` on CPython 3.14 on this platform; these environment constraints are noted but do not affect the new unit test and compile checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a604b301483249472357629d206e7)