### PR TITLE
モデル埋め込み次元をメタデータから動的に扱う（768固定撤廃）

### DIFF
--- a/app/application/usecase.py
+++ b/app/application/usecase.py
@@ -68,6 +68,28 @@ class Usecase:
 
         return self._accessor.load_index_with_metadata(model_id, aesthetic_model_name)
 
+
+    def _get_index_dimension(self, index, mean_vector: np.ndarray | None = None) -> int:
+        """読み込んだFAISS indexまたは平均ベクトルから検索次元を取得する。"""
+
+        index_dim = getattr(index, "d", None)
+        if index_dim is not None:
+            return int(index_dim)
+        if mean_vector is not None:
+            return int(mean_vector.size)
+        raise ValueError("Unable to determine search embedding dimension from index or mean vector.")
+
+    def _ensure_query_dimension(self, query_features: np.ndarray, index, mean_vector: np.ndarray | None = None) -> None:
+        """クエリ次元とインデックス次元が一致することを検証する。"""
+
+        expected_dim = self._get_index_dimension(index, mean_vector)
+        actual_dim = int(query_features.shape[-1])
+        if actual_dim != expected_dim:
+            raise ValueError(
+                f"Query embedding dimension mismatch: query has {actual_dim} dimensions, "
+                f"but the FAISS index expects {expected_dim}."
+            )
+
     def _normalize_result_size(self, result_size: int | None) -> int:
         """検索結果件数の上限を安全な正整数に正規化する。"""
 
@@ -227,10 +249,16 @@ class Usecase:
             list[ResultImageItem]: 距離に基づき生成した結果リスト。インデックス外参照が発生したIDはスキップし、`traceback`を標準出力へ表示する。
         """
         self._logger.info("query_features shape: %s", query_features.shape)
+        self._ensure_query_dimension(query_features, index, mean_vector)
 
         # Mean Centering
         if mean_centering:
-            if mean_vector is not None and mean_vector.size == query_features.shape[-1]:
+            if mean_vector is not None:
+                if mean_vector.size != query_features.shape[-1]:
+                    raise ValueError(
+                        f"Mean vector dimension mismatch: mean vector has {mean_vector.size} "
+                        f"dimensions, but query has {query_features.shape[-1]}."
+                    )
                 self._logger.info("Applying mean centering to query features.")
                 query_features = query_features.copy() - mean_vector.reshape(1, -1)
 
@@ -343,6 +371,8 @@ class Usecase:
         )
         # indexを読み込み
         index, item_list = self._get_index_and_items(model_id, aesthetic_model_name)
+        mean_vector = self._accessor.get_mean_meta_vector(model_id)
+        self._ensure_query_dimension(features, index, mean_vector)
 
         # 類似度を計算する
         scores: list[ResultImageItem] = self.similarity_eval(
@@ -500,12 +530,14 @@ class Usecase:
     ) -> ResultImageItemList:
         """乱数から検索する"""
 
-        # 単位超球面（Unit hypersphere）上から一様にベクトルをサンプリング
-        # similarity_evalの副作用で正規化されるため、ここでは正規化せずに生の乱数を渡す。
-        features: np.ndarray = np.random.normal(0, 1, [1, 768]).astype(np.float32)
-
         # indexを読み込み
         index, item_list = self._get_index_and_items(model_id, aesthetic_model_name)
+        mean_vector = self._accessor.get_mean_meta_vector(model_id)
+        dimension = self._get_index_dimension(index, mean_vector)
+
+        # 単位超球面（Unit hypersphere）上から一様にベクトルをサンプリング
+        # similarity_evalの副作用で正規化されるため、ここでは正規化せずに生の乱数を渡す。
+        features: np.ndarray = np.random.normal(0, 1, [1, dimension]).astype(np.float32)
 
         # 類似度を計算する
         scores: list[ResultImageItem] = self.similarity_eval(
@@ -514,7 +546,7 @@ class Usecase:
             result_size=self._normalize_result_size(result_size),
             query_features=features,
             mean_centering=True,
-            mean_vector=self._accessor.get_mean_meta_vector(model_id),
+            mean_vector=mean_vector,
         )
         scores = self.apply_aesthetic_quality_filter(
             model_id,
@@ -539,9 +571,13 @@ class Usecase:
         """クエリから検索する"""
 
         features = self.parse_search_query(search_query)
+        if features is None:
+            raise ValueError("Invalid search query vector format.")
 
         # indexを読み込み
         index, item_list = self._get_index_and_items(model_id, aesthetic_model_name)
+        mean_vector = self._accessor.get_mean_meta_vector(model_id)
+        self._ensure_query_dimension(features, index, mean_vector)
 
         # 類似度を計算する
         scores: list[ResultImageItem] = self.similarity_eval(
@@ -550,7 +586,7 @@ class Usecase:
             result_size=self._normalize_result_size(result_size),
             query_features=features,
             mean_centering=True,
-            mean_vector=self._accessor.get_mean_meta_vector(model_id),
+            mean_vector=mean_vector,
         )
 
         scores: list[ResultImageItem] = self.apply_aesthetic_quality_filter(
@@ -584,6 +620,8 @@ class Usecase:
         tokenizer: Tokenizer = self._accessor.load_tokenizer(model_id)
 
         query_features = self.parse_search_query(search_query)
+        if query_features is None:
+            raise ValueError("Invalid search query vector format.")
 
         text_features = (
             model.model_obj[0]
@@ -594,11 +632,14 @@ class Usecase:
             .copy()
         )
 
-        faiss.normalize_L2(text_features)
-        features = query_features + text_features * strength
-
         # indexを読み込み
         index, item_list = self._get_index_and_items(model_id, aesthetic_model_name)
+        mean_vector = self._accessor.get_mean_meta_vector(model_id)
+        self._ensure_query_dimension(query_features, index, mean_vector)
+        self._ensure_query_dimension(text_features, index, mean_vector)
+
+        faiss.normalize_L2(text_features)
+        features = query_features + text_features * strength
 
         # 類似度を計算する
         scores: list[ResultImageItem] = self.similarity_eval(
@@ -607,7 +648,7 @@ class Usecase:
             result_size=self._normalize_result_size(result_size),
             query_features=features,
             mean_centering=True,
-            mean_vector=self._accessor.get_mean_meta_vector(model_id),
+            mean_vector=mean_vector,
         )
 
         scores: list[ResultImageItem] = self.apply_aesthetic_quality_filter(

--- a/create_index.py
+++ b/create_index.py
@@ -765,7 +765,14 @@ def parse_arguments():
         default="Qwen/Qwen3-VL-Embedding-2B",
     )
     parser.add_argument(
-        "--search_model_out_dim", help="search_model_out_dim", type=int, default=768
+        "--search_model_out_dim",
+        help=(
+            "Optional output embedding dimension. If omitted, the dimension is "
+            "inferred from the first generated/stored embedding. Qwen MRL models "
+            "are truncated to this size when specified."
+        ),
+        type=int,
+        default=None,
     )
 
     parser.add_argument(
@@ -781,7 +788,14 @@ def parse_arguments():
     parser.add_argument("--batch_size", help="batch size", type=int, default=32)
     parser.add_argument("--num_workers", help="data loader workers", type=int, default=8)
     parser.add_argument("--nlist", help="centroid size", type=int, default=64)
-    parser.add_argument("--M", help="M", type=int, default=768)
+    parser.add_argument(
+        "--pq-m",
+        "--M",
+        dest="pq_m",
+        help="FAISS IVFPQ PQ subvector count (not embedding dimension).",
+        type=int,
+        default=64,
+    )
     parser.add_argument("--bits_per_code", help="bits_per_code", type=int, default=8)
     parser.add_argument(
         "--metas_faiss_index_file_name",
@@ -1092,11 +1106,11 @@ def load_image_meta_from_db(
         cur.execute(f"DROP TABLE IF EXISTS \"{temp_table}\"")
 
 
-def createIndex(n_centroids, M, bits_per_code, dim) -> faiss.IndexIVFPQ:
+def createIndex(n_centroids, pq_m, bits_per_code, dim) -> faiss.IndexIVFPQ:
 
     quantizer = faiss.IndexFlatIP(dim)
     index = faiss.IndexIVFPQ(
-        quantizer, dim, n_centroids, M, bits_per_code, faiss.METRIC_INNER_PRODUCT
+        quantizer, dim, n_centroids, pq_m, bits_per_code, faiss.METRIC_INNER_PRODUCT
     )
 
     return index
@@ -1157,11 +1171,12 @@ class OpenClipEmbeddingBackend(SearchEmbeddingBackend):
 class QwenVlEmbeddingBackend(SearchEmbeddingBackend):
     """Qwen3-VL-Embedding を使う検索エンコーダ。"""
 
-    def __init__(self, model_id: str, device: str):
+    def __init__(self, model_id: str, device: str, output_dim: int | None = None):
         from transformers import AutoModel, AutoProcessor
 
         self.device = device
         self.model_id = model_id
+        self.output_dim = output_dim
         dtype = torch.float16 if device.startswith("cuda") else torch.float32
         self.processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
         self.model = AutoModel.from_pretrained(
@@ -1198,6 +1213,15 @@ class QwenVlEmbeddingBackend(SearchEmbeddingBackend):
             raise RuntimeError("Qwen VL embedding model did not return embeddings.")
         return hidden.mean(dim=1)
 
+    def _apply_output_dim(self, features: torch.Tensor) -> torch.Tensor:
+        if self.output_dim is None:
+            return features
+        if features.shape[-1] < self.output_dim:
+            raise ValueError(
+                f"Requested output dimension {self.output_dim} exceeds model dimension {features.shape[-1]}."
+            )
+        return features[..., : self.output_dim].contiguous()
+
     @torch.no_grad()
     def encode_image_with_internal(self, image_inputs):
         if isinstance(image_inputs, dict):
@@ -1207,7 +1231,7 @@ class QwenVlEmbeddingBackend(SearchEmbeddingBackend):
             }
         image_inputs = self._move_inputs_to_device(image_inputs)
         outputs = self.model(**image_inputs, return_dict=True)
-        features = self._pool_outputs(outputs)
+        features = self._apply_output_dim(self._pool_outputs(outputs))
         return features, features
 
     @torch.no_grad()
@@ -1215,7 +1239,7 @@ class QwenVlEmbeddingBackend(SearchEmbeddingBackend):
         inputs = self.processor(text=texts, padding=True, return_tensors="pt")
         inputs = self._move_inputs_to_device(inputs)
         outputs = self.model(**inputs, return_dict=True)
-        return self._pool_outputs(outputs)
+        return self._apply_output_dim(self._pool_outputs(outputs))
 
 
 def safe_model_dir_name(value: str) -> str:
@@ -1258,7 +1282,7 @@ def load_search_embedding_backend(args, device) -> SearchEmbeddingBackend:
             device,
         )
     if args.search_backend == "qwen_vl":
-        return QwenVlEmbeddingBackend(args.search_model_id, device)
+        return QwenVlEmbeddingBackend(args.search_model_id, device, args.search_model_out_dim)
     raise ValueError(f"Unknown search backend: {args.search_backend}")
 
 
@@ -1290,12 +1314,16 @@ def filter_valid_image_meta(args, result, image_id_to_path):
     valid_meta_count = 0
     has_existing_metas = False
     uncreated_image_paths = []
-    expected_bytes = args.search_model_out_dim * np.dtype(np.float32).itemsize
+    expected_bytes = (
+        args.search_model_out_dim * np.dtype(np.float32).itemsize
+        if args.search_model_out_dim is not None
+        else None
+    )
 
     for image_id, meta in tqdm.tqdm(result, total=len(image_id_to_path)):
         if meta is not None:
             meta_view = memoryview(meta)
-            if meta_view.nbytes == expected_bytes:
+            if expected_bytes is None or meta_view.nbytes == expected_bytes:
                 valid_meta_count += 1
                 has_existing_metas = True
                 continue
@@ -1303,6 +1331,34 @@ def filter_valid_image_meta(args, result, image_id_to_path):
         uncreated_image_paths.append(image_id_to_path[image_id])
 
     return ImageMetaFilterStats(valid_meta_count, has_existing_metas), uncreated_image_paths
+
+
+def infer_meta_dimension(con: sqlite3.Connection) -> int | None:
+    """保存済みmeta BLOBからfloat32埋め込み次元を推定する。"""
+    row = con.execute(
+        "SELECT meta FROM image_meta WHERE meta IS NOT NULL LIMIT 1"
+    ).fetchone()
+    if row is None:
+        return None
+    meta_size = memoryview(row[0]).nbytes
+    item_size = np.dtype(np.float32).itemsize
+    if meta_size % item_size != 0:
+        raise ValueError(f"Invalid meta byte size for float32 vector: {meta_size}")
+    return meta_size // item_size
+
+
+def resolve_embedding_dimension(args, con: sqlite3.Connection) -> int:
+    """CLI指定または保存済みmetaから現在の埋め込み次元を決定する。"""
+    if args.search_model_out_dim is not None:
+        return int(args.search_model_out_dim)
+    inferred = infer_meta_dimension(con)
+    if inferred is None:
+        raise ValueError(
+            "Embedding dimension is unknown because no embeddings were generated or stored."
+        )
+    args.search_model_out_dim = inferred
+    print(f"Inferred search_model_out_dim={inferred}")
+    return inferred
 
 
 def collect_orphan_db_records(
@@ -1481,6 +1537,9 @@ def extract_image_features(
                         tagging_results,
                     )
                 ):
+                    if args.search_model_out_dim is None:
+                        args.search_model_out_dim = int(new_search_meta.shape[0])
+                        print(f"Detected search_model_out_dim={args.search_model_out_dim}")
                     if new_search_meta.shape[0] != args.search_model_out_dim:
                         print(f"{new_search_meta.shape[0]} != {args.search_model_out_dim}")
                         continue
@@ -1878,8 +1937,8 @@ def compute_mean_vector(
 
 def stream_build_faiss(
     db_path: str,
-    nlist: int, M: int, bits_per_code: int,
-    d: int,                       # args.search_model_out_dim
+    nlist: int, pq_m: int, bits_per_code: int,
+    d: int,
     out_index_path: str,
     batch_size: int = 50_000,     # メモリに合わせて調整
     train_samples: int = 2_000_000, # 訓練に使う最大サンプル数（d次元×この件数だけ常駐）
@@ -1903,6 +1962,11 @@ def stream_build_faiss(
         np.save(mean_vec_path, mean_vec)
         print(f"Saved mean vector to {mean_vec_path}")
 
+        metadata_path = out_index_path + ".meta.json"
+        with open(metadata_path, "w", encoding="utf-8") as f:
+            json.dump({"embedding_dim": d, "pq_m": pq_m}, f, ensure_ascii=False, indent=2)
+        print(f"Saved index metadata to {metadata_path}")
+
         # -------- パス1: 訓練 --------
         train_buf = collect_train_samples_algL(con, d, train_samples, batch_size, total=total)
 
@@ -1910,7 +1974,7 @@ def stream_build_faiss(
         train_buf -= mean_vec
         faiss.normalize_L2(train_buf)
 
-        index = createIndex(nlist, M, bits_per_code, d)  # 既存関数を利用
+        index = createIndex(nlist, pq_m, bits_per_code, d)  # 既存関数を利用
         print(f"train {train_buf.shape}")
         index.train(train_buf)
         del train_buf  # 訓練後は解放
@@ -1998,12 +2062,13 @@ def main():
             init_db(cur)
 
             recalc_batch = getattr(args, "recalc_aesthetic_batch_size", 16384)
+            embedding_dim = resolve_embedding_dimension(args, con)
             recalc_aesthetic_scores(
                 con,
                 aesthetic_model,
                 pony_scorer,
                 device,
-                out_dim=args.search_model_out_dim,
+                out_dim=embedding_dim,
                 batch_size=recalc_batch,
             )
 
@@ -2016,9 +2081,9 @@ def main():
         stream_build_faiss(
             search_model_meta_dir,
             args.nlist,
-            args.M,
+            args.pq_m,
             args.bits_per_code,
-            args.search_model_out_dim,
+            embedding_dim,
             f"{search_model_meta_dir}/{args.metas_faiss_index_file_name}",
             batch_size=100_000,
             train_samples=2_000_000,
@@ -2215,7 +2280,13 @@ def main():
 
     del con, cur
 
-    stream_build_faiss(search_model_meta_dir, args.nlist, args.M, args.bits_per_code, args.search_model_out_dim,
+    con = connect_db(search_model_meta_dir)
+    try:
+        embedding_dim = resolve_embedding_dimension(args, con)
+    finally:
+        con.close()
+
+    stream_build_faiss(search_model_meta_dir, args.nlist, args.pq_m, args.bits_per_code, embedding_dim,
         f"{search_model_meta_dir}/{args.metas_faiss_index_file_name}", batch_size=100_000, train_samples=2_000_000
     )
 


### PR DESCRIPTION
### Motivation
- 既存コードで埋め込み次元を固定の768として扱っていたため、Qwen等の異なる出力次元や将来のモデルで不整合が発生していた。 
- FAISS IVFPQの引数`M`が埋め込み次元と混同されており、PQサブベクトル数として明確に分離する必要があった。 
- 保存済みmetaや最初に生成した埋め込みから実際の次元を決定することで、インデックス作成・平均ベクトル計算・検索時の一貫性を確保する。 

### Description
- `create_index.py`のCLIを変更し、`--search_model_out_dim`のデフォルトを`None`にして任意指定にし、未指定時は保存済みmetaまたは最初の生成埋め込みから次元を推定するロジックを追加した。 
- FAISS IVFPQのパラメータを`--pq-m`（`pq_m`）に分離し、旧`--M`を互換的にエイリアスとして扱い、`createIndex`や`stream_build_faiss`の署名を更新した。 
- Qwenバックエンドに`output_dim`を渡して出力を切り詰める`_apply_output_dim`を追加し、MRLでの1024/512→指定次元化に対応した。 
- インデックス作成パスでmean vectorを保存し、`*.meta.json`に`embedding_dim`と`pq_m`を書き出すようにしてインデックスメタ情報を永続化した。 
- `app/application/usecase.py`にインデックス/meanベクトルから検索次元を取得する`_get_index_dimension`と、クエリ次元とインデックス次元の整合性を検証する`_ensure_query_dimension`を追加し、`search_random`/`search_query`/`add_text_features`などで明示的な次元検査と適切な乱数次元生成を行うようにした。 

### Testing
- `python -m py_compile create_index.py app/application/usecase.py` を実行して構文チェックは成功した。 
- `pytest -q` を実行したが、実行環境に必要な依存（`numpy`等）やプロジェクトパスの問題でテスト収集に失敗したため不合格（環境依存のためコード上の単体失敗ではない）。 
- `uv run pytest -q` を試行したが、現在のCPython環境（3.14）で`onnxruntime-gpu==1.23.2`のホイールが存在しないため実行できず失敗した（環境制約による）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32f27dc7bc8324901495535527c32d)