### PR TITLE
open_clip以外の検索モデルをUIで選択可能にする

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,7 +19,7 @@ def main():
 
     accessor: LocalAccessor = LocalAccessor(meta_dir_path)
 
-    repository: LocalRepository = LocalRepository(image_dir_path)
+    repository: LocalRepository = LocalRepository(image_dir_path, meta_dir_path)
     startup_model_id = ModelId("ViT-L-14", "openai")
 
     in_usecase: usecase.Usecase = usecase.Usecase(

--- a/app/infrastructure/local_accessor.py
+++ b/app/infrastructure/local_accessor.py
@@ -23,6 +23,12 @@ from app.domain.domain_object import (
 )
 from app.application.accessor import Accessor
 from app.application.embedding_backend import SearchEmbeddingBackend, to_float32_2d_array
+from app.infrastructure.model_metadata import (
+    default_model_dir_name,
+    has_search_index,
+    read_model_metadata,
+    safe_model_dir_name,
+)
 
 
 class OpenClipEmbeddingBackend(SearchEmbeddingBackend):
@@ -140,13 +146,42 @@ class LocalAccessor(Accessor):
 
     def __init__(self, meta_dir_path) -> None:
         self._logger = logging.getLogger(__name__)
-        self._meta_dir_path = meta_dir_path
+        self._meta_dir_path = pathlib.Path(meta_dir_path)
         self._id_to_path: Dict[ImageId, pathlib.Path] = {}
+
+    def _search_model_meta_dir(self, model_id: ModelId) -> pathlib.Path:
+        """Return the index directory for a ModelId, including metadata-backed safe names."""
+        candidates = [
+            self._meta_dir_path / default_model_dir_name(model_id),
+            self._meta_dir_path / safe_model_dir_name(model_id.model_name),
+        ]
+        for candidate in candidates:
+            metadata = read_model_metadata(candidate)
+            if metadata is not None and (
+                metadata.model_name,
+                metadata.pretrained,
+            ) == (model_id.model_name, model_id.pretrained):
+                return candidate
+            if metadata is None and candidate.exists():
+                return candidate
+
+        if self._meta_dir_path.is_dir():
+            for index_dir in self._meta_dir_path.iterdir():
+                if not has_search_index(index_dir):
+                    continue
+                metadata = read_model_metadata(index_dir)
+                if metadata is not None and (
+                    metadata.model_name,
+                    metadata.pretrained,
+                ) == (model_id.model_name, model_id.pretrained):
+                    return index_dir
+
+        return candidates[0]
 
     def load_image_feature(self, model_id: ModelId, image_id: ImageId) -> np.ndarray:
         """meta_dir配下のmodel-pretrained/image_id.npyから画像特徴量を読み込み、毎回np.loadで返す（キャッシュ無し）。"""
         return np.load(
-            f"{self._meta_dir_path}/{model_id.model_name}-{model_id.pretrained}/{image_id}.npy"
+            str(self._search_model_meta_dir(model_id) / f"{image_id}.npy")
         )
 
     @cache
@@ -178,11 +213,11 @@ class LocalAccessor(Accessor):
     ) -> Tuple[Any, List[ImageItem]]:
         """meta_dir/model-pretrainedのFAISS indexとSQLiteメタを読み込み、画像パス順のImageItemリストとindexをタプルで返す（@cacheで結果共有）。"""
         index = faiss.read_index(
-            f'{self._meta_dir_path}/{model_id.model_name}-{model_id.pretrained}/{"metafiles.index"}'
+            str(self._search_model_meta_dir(model_id) / "metafiles.index")
         )
 
         con: sqlite3.Connection = sqlite3.connect(
-            f"{self._meta_dir_path}/{model_id.model_name}-{model_id.pretrained}/sqlite_image_meta.db",
+            str(self._search_model_meta_dir(model_id) / "sqlite_image_meta.db"),
             isolation_level="DEFERRED",
         )
         result: pd.DataFrame = pd.read_sql_query(
@@ -281,7 +316,7 @@ class LocalAccessor(Accessor):
         """ModelIdからimage meta全体の平均ベクトルを取得する。"""
 
         mean_vector = np.load(
-                f"{self._meta_dir_path}/{model_id.model_name}-{model_id.pretrained}/metafiles.index.mean.npy"
-            )
+            str(self._search_model_meta_dir(model_id) / "metafiles.index.mean.npy")
+        )
 
         return mean_vector

--- a/app/infrastructure/local_repository.py
+++ b/app/infrastructure/local_repository.py
@@ -15,6 +15,12 @@ from typing import List, Sequence
 import concurrent.futures
 import zipfile
 
+from app.infrastructure.model_metadata import (
+    default_model_dir_name,
+    has_search_index,
+    read_model_metadata,
+)
+
 import tqdm
 
 from app.domain.domain_object import (
@@ -50,12 +56,14 @@ class LocalRepository(Repository):
     def __init__(
         self,
         image_dir_path: pathlib.Path,
+        meta_dir_path: pathlib.Path | None = None,
         *,
         scan_timeout_sec: float = _SCAN_TIMEOUT_SEC,
         scan_parallelism: int = _PARALLEL,
     ) -> None:
         self._logger = logging.getLogger(__name__)
         self._image_dir_path: pathlib.Path = image_dir_path
+        self._meta_dir_path: pathlib.Path = meta_dir_path or pathlib.Path('./clip_meta')
         self._id_to_path: dict[ImageId, pathlib.Path] = {}
         self._scan_timeout_sec = scan_timeout_sec
         self._scan_parallelism = scan_parallelism
@@ -314,20 +322,53 @@ class LocalRepository(Repository):
 
     @cache
     def load_all_model_item(self) -> list[ModelItem]:
-        """open_clip の事前学習モデル一覧を取得し、キャッシュ済みのModelItemに変換する。
+        """利用可能な検索モデル一覧を返す。
 
-        - ``open_clip.list_pretrained()`` が返す (モデル名, データセット) のペアを ``ModelItem`` にマッピングする。
-        - 結果は ``functools.cache`` によりメモ化され、同一プロセス内で再計算を避ける。
-        - 戻り値は ``ModelItem`` オブジェクトのリスト。
+        open_clip が提供する事前学習モデルに加えて、meta_dir 配下に
+        ``metafiles.index`` と ``sqlite_image_meta.db`` を持つインデックス
+        ディレクトリを検出し、UI で選択可能な ModelItem として追加する。
+        ``model_meta.json`` がある場合は、Qwen などの repo ID を安全な
+        ディレクトリ名へ変換したインデックスから元の ModelId と表示名を復元する。
         """
 
-        items: list[ModelItem] = [
-            ModelItem(
+        items_by_key: dict[tuple[str, str], ModelItem] = {}
+
+        for model_name, dataset in open_clip.list_pretrained():
+            item = ModelItem(
                 ModelId(model_name, dataset), ModelName(f"{model_name}-{dataset}")
             )
-            for (model_name, dataset) in open_clip.list_pretrained()
-        ]
-        return items
+            items_by_key[(model_name, dataset)] = item
+
+        for index_dir in self._iter_search_index_dirs():
+            item = self._model_item_from_index_dir(index_dir)
+            items_by_key[(item.id.model_name, item.id.pretrained)] = item
+
+        return sorted(
+            items_by_key.values(),
+            key=lambda item: item.display_name.name.lower(),
+        )
+
+    def _iter_search_index_dirs(self) -> list[pathlib.Path]:
+        if not self._meta_dir_path.is_dir():
+            return []
+        return sorted(
+            (path for path in self._meta_dir_path.iterdir() if has_search_index(path)),
+            key=lambda path: path.name.lower(),
+        )
+
+    def _model_item_from_index_dir(self, index_dir: pathlib.Path) -> ModelItem:
+        metadata = read_model_metadata(index_dir)
+        if metadata is not None:
+            return metadata.to_model_item()
+
+        model_name, separator, pretrained = index_dir.name.rpartition("-")
+        if not separator:
+            model_name = index_dir.name
+            pretrained = ""
+        return ModelItem(
+            ModelId(model_name, pretrained),
+            ModelName(default_model_dir_name(ModelId(model_name, pretrained))),
+        )
 
     @cache
     def load_image(self, image_id: ImageId) -> Image:

--- a/app/infrastructure/model_metadata.py
+++ b/app/infrastructure/model_metadata.py
@@ -1,0 +1,73 @@
+"""Search-index model metadata helpers."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from dataclasses import asdict, dataclass
+
+from app.domain.domain_object import ModelId, ModelItem, ModelName
+
+MODEL_METADATA_FILENAME = "model_meta.json"
+INDEX_FILENAME = "metafiles.index"
+SQLITE_METADATA_FILENAME = "sqlite_image_meta.db"
+
+
+@dataclass(frozen=True)
+class SearchModelMetadata:
+    """Metadata that restores a ModelItem from an index directory name."""
+
+    model_name: str
+    pretrained: str
+    display_name: str
+
+    def to_model_item(self) -> ModelItem:
+        return ModelItem(
+            ModelId(self.model_name, self.pretrained),
+            ModelName(self.display_name),
+        )
+
+
+def safe_model_dir_name(value: str) -> str:
+    """Convert a repository/model id into a path-safe directory name."""
+    return value.replace("/", "--").replace("\\", "--").replace(":", "_")
+
+
+def default_model_dir_name(model_id: ModelId) -> str:
+    return f"{model_id.model_name}-{model_id.pretrained}"
+
+
+def has_search_index(directory: pathlib.Path) -> bool:
+    return (
+        directory.is_dir()
+        and (directory / INDEX_FILENAME).is_file()
+        and (directory / SQLITE_METADATA_FILENAME).is_file()
+    )
+
+
+def read_model_metadata(directory: pathlib.Path) -> SearchModelMetadata | None:
+    path = directory / MODEL_METADATA_FILENAME
+    if not path.is_file():
+        return None
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    model_name = data.get("model_name")
+    pretrained = data.get("pretrained", "")
+    display_name = data.get("display_name")
+    if not isinstance(model_name, str) or not isinstance(pretrained, str):
+        return None
+    if not isinstance(display_name, str) or not display_name:
+        display_name = f"{model_name}-{pretrained}" if pretrained else model_name
+    return SearchModelMetadata(model_name, pretrained, display_name)
+
+
+def write_model_metadata(directory: pathlib.Path, metadata: SearchModelMetadata) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / MODEL_METADATA_FILENAME).write_text(
+        json.dumps(asdict(metadata), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )

--- a/app/presentation/view/index.html
+++ b/app/presentation/view/index.html
@@ -88,12 +88,12 @@
                             <v-autocomplete
                             v-model="model_name"
                             label="model_name"
-                            :items="['ViT-L-14','ViT-bigG-14','ViT-L-14-336', 'ViT-SO400M-14-SigLIP-384', 'ViT-SO400M-16-SigLIP-i18n-256']"
+                            :items="modelNameItems"
                             ></v-autocomplete>
                             <v-autocomplete
                             v-model="pretrained"
                             label="pretrained"
-                            :items="['openai','laion2b_s39b_b160k','commonpool_xl_s13b_b90k', 'webli']"
+                            :items="pretrainedItems"
                             ></v-autocomplete>
                             <v-autocomplete
                             v-model="aesthetic_model_name"

--- a/app/presentation/view/js/main.js
+++ b/app/presentation/view/js/main.js
@@ -30,6 +30,7 @@ const app = Vue.createApp({
             resultSize: 2048,
             model_name: "ViT-L-14",
             pretrained: "openai",
+            modelItems: [],
             search_query: "",
             showedItemIndex: 0,
             aesthetic_quality_beta: 0.00,
@@ -108,6 +109,18 @@ const app = Vue.createApp({
             this.onModelChange()
         }
     },
+    computed:{
+        modelNameItems() {
+            const names = this.modelItems.map(item => item.model_name)
+            return [...new Set([this.model_name, ...names])]
+        },
+        pretrainedItems() {
+            const values = this.modelItems
+                .filter(item => item.model_name === this.model_name)
+                .map(item => item.pretrained)
+            return [...new Set([this.pretrained, ...values])]
+        },
+    },
     methods:{
 
         /**
@@ -115,8 +128,16 @@ const app = Vue.createApp({
          */
         init() {
 
+            this.loadModelItems()
             this.initBuffer()
             .then(() => this.initImage())
+        },
+
+        loadModelItems() {
+            return repository.getModelItems()
+            .then(items => {
+                this.modelItems = items
+            })
         },
 
         onModelChange(){

--- a/app/presentation/view/js/modules/repository.js
+++ b/app/presentation/view/js/modules/repository.js
@@ -19,6 +19,17 @@ function normalizeResultSize(resultSize) {
 }
 
 
+
+/**
+ * 利用可能な検索モデル一覧を取得する。
+ *
+ * @return {Promise<{model_name:string, pretrained:string}[]>}
+ */
+export async function getModelItems() {
+
+    return axios.get(`/model_item`).then(res => res.data)
+}
+
 /**
  * 画像項目のIDから画像のURLを取得する
  * 

--- a/create_index.py
+++ b/create_index.py
@@ -25,6 +25,11 @@ import faiss
 import huggingface_hub
 import numpy as np
 import open_clip
+
+from app.infrastructure.model_metadata import (
+    SearchModelMetadata,
+    write_model_metadata,
+)
 import pandas as pd
 import torch
 import torch.nn as nn
@@ -1249,11 +1254,22 @@ def safe_model_dir_name(value: str) -> str:
 def create_search_model_meta_dir(args):
     if args.search_backend == "open_clip":
         model_dir_name = f"{args.search_model_name}-{args.search_model_pretrained}"
+        metadata = SearchModelMetadata(
+            model_name=args.search_model_name,
+            pretrained=args.search_model_pretrained,
+            display_name=model_dir_name,
+        )
     else:
         model_dir_name = safe_model_dir_name(args.search_model_id)
-    search_model_meta_dir = f"{args.meta_dir}/{model_dir_name}"
-    os.makedirs(search_model_meta_dir, exist_ok=True)
-    return search_model_meta_dir
+        metadata = SearchModelMetadata(
+            model_name=args.search_model_id,
+            pretrained="",
+            display_name=args.search_model_id,
+        )
+    search_model_meta_dir = pathlib.Path(args.meta_dir) / model_dir_name
+    search_model_meta_dir.mkdir(parents=True, exist_ok=True)
+    write_model_metadata(search_model_meta_dir, metadata)
+    return str(search_model_meta_dir)
 
 
 def configure_torch_backends():


### PR DESCRIPTION
### Motivation

- UI が `open_clip.list_pretrained()` のみを参照していたため、Qwen など `open_clip` 以外で作成したインデックスが選択肢に現れない問題を解消する。 

### Description

- 追加した `app/infrastructure/model_metadata.py` で `model_meta.json` の読み書き、インデックス判定 (`metafiles.index`/`sqlite_image_meta.db`) と安全なディレクトリ名変換を提供する。 
- `LocalRepository` に `meta_dir_path` 引数を追加し、`load_all_model_item()` を拡張して `open_clip.list_pretrained()` に加えて `meta_dir` 配下のインデックスディレクトリを検出して `ModelItem` を生成するようにした。 
- `LocalAccessor` にインデックス解決ロジックを追加し、`model_meta.json` を参照して安全化されたディレクトリ名から元の `ModelId` と表示名を復元してインデックス/SQLite を読み込めるようにした。 
- `create_index.py` のインデックス作成処理で `model_meta.json` を保存するようにして、Qwen のようなリポジトリ ID を安全なディレクトリ名に変換しても元情報が復元できるようにした。 
- フロントエンドは既定の `ViT-L-14/openai` を維持しつつ、`/model_item` エンドポイントから取得したモデル一覧で `v-autocomplete`（model_name / pretrained）の選択肢を動的に構築するように変更した（`app/presentation/view/js/main.js`、`app/presentation/view/js/modules/repository.js`、`app/presentation/view/index.html`）。

### Testing

- 実装ファイルのバイトコードチェックとして `python -m compileall app create_index.py` を実行して成功した。 
- PIL/OpenCLIP 等をスタブして作成した一時 `meta` ディレクトリに対し `LocalRepository(...).load_all_model_item()` を呼ぶ簡易検査を行い、`open_clip` のモデルと `Qwen` の安全ディレクトリ名インデックスが両方検出されることを確認した（スタブテストは `ok` を出力）。 
- フル実行は環境依存で一部失敗しており、`uv run python ...` 実行はローカル環境の CPython 3.14 に対して `onnxruntime-gpu==1.23.2` の wheel が提供されていないため依存解決で実行できなかった（警告として記録）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32f5ddd49c8324aea9f85c6237d2a3)