### PR TITLE
Warm search cache on startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,6 +25,7 @@ def main():
     in_usecase: usecase.Usecase = usecase.Usecase(
         repository, accessor, startup_model_id
     )
+    in_usecase.warmup_search_cache(startup_model_id)
     start_app(in_usecase)
 
 

--- a/app/application/usecase.py
+++ b/app/application/usecase.py
@@ -125,6 +125,36 @@ class Usecase:
             self._sort_result_items(scores)[:normalized_result_size], search_query
         )
 
+
+    def warmup_search_cache(
+        self,
+        model_id: ModelId,
+        search_text: str = "An image a cat.",
+        aesthetic_model_name: str = "original",
+    ) -> ResultImageItemList:
+        """起動時に代表的なテキスト検索を実行し、検索に必要なデータをキャッシュする。
+
+        実際のユーザー検索と同じ経路で埋め込みバックエンド、FAISSインデックス、
+        画像メタデータ、平均ベクトルを読み込むことで、初回検索時の待ち時間を
+        アプリケーション起動時に前倒しする。
+        """
+
+        self._logger.info(
+            "起動時検索キャッシュを作成します: model_id=%s search_text=%s aesthetic_model_name=%s",
+            model_id,
+            search_text,
+            aesthetic_model_name,
+        )
+        return self.search_text(
+            model_id=model_id,
+            text=UploadText(search_text),
+            aesthetic_quality_beta=0.0,
+            aesthetic_quality_range_min=0.0,
+            aesthetic_quality_range_max=10.0,
+            aesthetic_model_name=aesthetic_model_name,
+            result_size=1,
+        )
+
     # ===================================================================
 
     def get_all_image_item(self) -> list[ImageItem]:

--- a/tests/test_usecase_result_sorting.py
+++ b/tests/test_usecase_result_sorting.py
@@ -22,8 +22,11 @@ from app.domain.domain_object import (
     ImageId,
     ImageItem,
     ImageName,
+    ModelId,
     ResultImageItem,
+    ResultImageItemList,
     Score,
+    UploadText,
 )
 
 
@@ -58,6 +61,30 @@ class UsecaseResultSortingTests(unittest.TestCase):
         self.assertEqual(self.usecase._normalize_result_size(None), 2048)
         self.assertEqual(self.usecase._normalize_result_size("invalid"), 2048)
         self.assertEqual(self.usecase._normalize_result_size(0), 1)
+
+    def test_warmup_search_cache_runs_minimal_text_search_with_defaults(self):
+        model_id = ModelId("ViT-L-14", "openai")
+        calls = []
+        expected = ResultImageItemList([], "query")
+        self.usecase._logger = types.SimpleNamespace(info=lambda *args, **kwargs: None)
+
+        def fake_search_text(**kwargs):
+            calls.append(kwargs)
+            return expected
+
+        self.usecase.search_text = fake_search_text
+
+        result = self.usecase.warmup_search_cache(model_id)
+
+        self.assertIs(result, expected)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["model_id"], model_id)
+        self.assertEqual(calls[0]["text"], UploadText("An image a cat."))
+        self.assertEqual(calls[0]["aesthetic_quality_beta"], 0.0)
+        self.assertEqual(calls[0]["aesthetic_quality_range_min"], 0.0)
+        self.assertEqual(calls[0]["aesthetic_quality_range_max"], 10.0)
+        self.assertEqual(calls[0]["aesthetic_model_name"], "original")
+        self.assertEqual(calls[0]["result_size"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Reduce first-search latency by preloading embedding backend, FAISS index, image metadata and mean vector at application startup.

### Description

- Add `Usecase.warmup_search_cache` which performs a minimal text search using the default query `"An image a cat."` and calls `search_text` with `result_size=1` and neutral aesthetic settings to exercise the normal search-loading path.
- Invoke `in_usecase.warmup_search_cache(startup_model_id)` in `app.py` before `start_app` so cache warming runs during startup.
- Add a unit test `test_warmup_search_cache_runs_minimal_text_search_with_defaults` in `tests/test_usecase_result_sorting.py` to verify the warmup calls `search_text` with expected default parameters.

### Testing

- Ran `python -m unittest tests/test_usecase_result_sorting.py`, which passed (tests ran successfully).
- Ran `python -m compileall app.py app tests`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32f7918c8c8324b1e277dc4d8529b0)