### PR TITLE
Make Qwen VL preprocess picklable and move image batching to main process

### DIFF
--- a/create_index.py
+++ b/create_index.py
@@ -61,8 +61,13 @@ def safe_collate(batch):
     wd_inputs = [b[3] for b in batch]
     z3d_inputs = [b[4] for b in batch]
 
+    if search_inputs and isinstance(search_inputs[0], Image.Image):
+        batched_search_inputs = search_inputs
+    else:
+        batched_search_inputs = default_collate(search_inputs)
+
     return (
-        default_collate(search_inputs),
+        batched_search_inputs,
         default_collate(metadata_inputs) if metadata_inputs[0] is not None else None,
         default_collate(indices),
         default_collate(wd_inputs),
@@ -1201,6 +1206,19 @@ class OpenClipEmbeddingBackend(SearchEmbeddingBackend):
         return self.model.encode_text(tokens)
 
 
+class QwenVlImagePreprocess:
+    """Picklable image transform for Qwen VL search inputs.
+
+    Qwen preprocessing is intentionally deferred to the main-process batch
+    path because the processor owns non-trivial model state and may not be
+    picklable under multiprocessing spawn. DataLoader workers only return
+    lightweight PIL images.
+    """
+
+    def __call__(self, image: Image.Image) -> Image.Image:
+        return image.copy()
+
+
 class QwenVlEmbeddingBackend(SearchEmbeddingBackend):
     """Qwen3-VL-Embedding を使う検索エンコーダ。"""
 
@@ -1221,10 +1239,7 @@ class QwenVlEmbeddingBackend(SearchEmbeddingBackend):
 
     @property
     def preprocess(self):
-        def _preprocess(image: Image.Image):
-            return self.processor(images=image, return_tensors="pt")
-
-        return _preprocess
+        return QwenVlImagePreprocess()
 
     def _move_inputs_to_device(self, inputs):
         if isinstance(inputs, dict):
@@ -1544,6 +1559,17 @@ def extract_image_features(
                 batched_wd_inputs,
                 batched_z3d_inputs,
             ) = batch
+
+            if (
+                isinstance(batched_image_input, list)
+                and batched_image_input
+                and isinstance(batched_image_input[0], Image.Image)
+            ):
+                batched_image_input = search_model.processor(
+                    images=batched_image_input,
+                    padding=True,
+                    return_tensors="pt",
+                )
 
             batched_image_input = _to_device(batched_image_input, device)
             batched_metadata_input = _to_device(batched_metadata_input, device)


### PR DESCRIPTION
### Motivation
- Prevent multiprocessing spawn serialization failures caused by a nested local preprocessing closure for the Qwen VL backend.  
- Avoid capturing `self` or non-picklable model state in worker-side transforms so `DataLoader` workers can run under Windows `spawn`.  
- Batch Qwen processor calls in the main process to keep worker outputs lightweight and picklable.

### Description
- Introduce a module-scope callable `QwenVlImagePreprocess` that simply returns a `PIL.Image` copy so the `preprocess` property no longer returns a nested function.  
- Change `QwenVlEmbeddingBackend.preprocess` to return `QwenVlImagePreprocess()` instead of a local closure so the transform is importable and picklable.  
- Update `safe_collate` to preserve Qwen search inputs as a list of `PIL.Image` objects (avoid `default_collate` for images) so batching can be done in the main process.  
- In `extract_image_features` run `search_model.processor(images=..., padding=True, return_tensors="pt")` when `batched_image_input` is a list of `PIL.Image` instances, then move the produced tensors to the target device, keeping Qwen preprocessing out of worker transforms.

### Testing
- Parsed the updated module with `ast.parse` which succeeded.  
- Ran an AST-based check confirming `QwenVlEmbeddingBackend.preprocess` contains no nested callables which succeeded.  
- Attempted a `DataLoader` spawn/pickle test that requires `PIL` which failed in the test environment due to `ModuleNotFoundError: No module named 'PIL'`.  
- Attempted to run the full indexing command `uv run create_index.py --search_backend qwen_vl --num_workers 8` but it was blocked by the environment due to an incompatible `onnxruntime-gpu==1.23.2` wheel for the current CPython ABI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32fbb098b48324b2f0e412bc0f266c)