### PR TITLE
Pad variable-length Qwen processor outputs at batch collation

### DIFF
--- a/create_index.py
+++ b/create_index.py
@@ -48,6 +48,72 @@ Image.MAX_IMAGE_PIXELS = 268_435_456
 # 共通ヘルパー
 # =========================
 
+QWEN_VARIABLE_IMAGE_KEYS = {
+    "pixel_values",
+    "pixel_values_videos",
+    "image_grid_thw",
+    "video_grid_thw",
+}
+
+
+def _tensor_shapes_differ(values: list[Any]) -> bool:
+    tensor_shapes = [tuple(value.shape) for value in values if torch.is_tensor(value)]
+    return bool(tensor_shapes) and any(shape != tensor_shapes[0] for shape in tensor_shapes[1:])
+
+
+def _is_variable_length_qwen_inputs(search_inputs: list[Any]) -> bool:
+    """Return True for per-image Qwen processor dicts that cannot use default_collate."""
+
+    if not search_inputs or not all(isinstance(item, dict) for item in search_inputs):
+        return False
+
+    common_keys = set(search_inputs[0])
+    if not common_keys.intersection(QWEN_VARIABLE_IMAGE_KEYS):
+        return False
+
+    return any(
+        _tensor_shapes_differ([item[key] for item in search_inputs if key in item])
+        for key in common_keys
+    )
+
+
+def _pad_tensors_to_common_shape(values: list[torch.Tensor]) -> torch.Tensor:
+    """Pad tensors with zeros to the per-dimension max shape, then stack."""
+
+    max_shape = tuple(max(value.shape[dim] for value in values) for dim in range(values[0].ndim))
+    padded_values = []
+    for value in values:
+        padded = value.new_full(max_shape, 0)
+        slices = tuple(slice(0, size) for size in value.shape)
+        padded[slices] = value
+        padded_values.append(padded)
+    return torch.stack(padded_values, dim=0)
+
+
+def _collate_qwen_processor_inputs(search_inputs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Collate Qwen processor output dictionaries, padding variable tensor fields."""
+
+    collated: dict[str, Any] = {}
+    keys = search_inputs[0].keys()
+    for key in keys:
+        values = [item[key] for item in search_inputs]
+        if all(torch.is_tensor(value) for value in values):
+            collated[key] = (
+                _pad_tensors_to_common_shape(values)
+                if _tensor_shapes_differ(values)
+                else default_collate(values)
+            )
+        else:
+            collated[key] = default_collate(values)
+    return collated
+
+
+def _collate_search_inputs(search_inputs: list[Any]):
+    if _is_variable_length_qwen_inputs(search_inputs):
+        return _collate_qwen_processor_inputs(search_inputs)
+    return default_collate(search_inputs)
+
+
 def safe_collate(batch):
     """Custom collate that bundles search, metadata, and tagger inputs."""
 
@@ -62,7 +128,7 @@ def safe_collate(batch):
     z3d_inputs = [b[4] for b in batch]
 
     return (
-        default_collate(search_inputs),
+        _collate_search_inputs(search_inputs),
         default_collate(metadata_inputs) if metadata_inputs[0] is not None else None,
         default_collate(indices),
         default_collate(wd_inputs),

--- a/tests/test_qwen_collate.py
+++ b/tests/test_qwen_collate.py
@@ -1,0 +1,219 @@
+import sys
+import types
+import unittest
+
+
+
+def _install_dummy_modules():
+    numpy_mod = types.ModuleType("numpy")
+    numpy_mod.ndarray = object
+    numpy_mod.float32 = "float32"
+
+    pil_mod = types.ModuleType("PIL")
+    pil_image_mod = types.ModuleType("PIL.Image")
+    pil_image_file_mod = types.ModuleType("PIL.ImageFile")
+    pil_image_mod.MAX_IMAGE_PIXELS = None
+    pil_image_mod.Image = object
+    pil_image_mod.LANCZOS = 1
+    pil_mod.Image = pil_image_mod
+    pil_mod.ImageFile = pil_image_file_mod
+
+    dummy_modules = {
+        "numpy": numpy_mod,
+        "PIL": pil_mod,
+        "PIL.Image": pil_image_mod,
+        "PIL.ImageFile": pil_image_file_mod,
+        "faiss": types.ModuleType("faiss"),
+        "huggingface_hub": types.ModuleType("huggingface_hub"),
+        "open_clip": types.ModuleType("open_clip"),
+        "pandas": types.ModuleType("pandas"),
+        "tqdm": types.ModuleType("tqdm"),
+        "onnxruntime": types.ModuleType("onnxruntime"),
+    }
+
+    torch_mod = types.ModuleType("torch")
+    torch_utils = types.ModuleType("torch.utils")
+    torch_utils_data = types.ModuleType("torch.utils.data")
+    torch_utils_data_utils = types.ModuleType("torch.utils.data._utils")
+    torch_utils_data_utils_collate = types.ModuleType("torch.utils.data._utils.collate")
+    torch_nn = types.ModuleType("torch.nn")
+    torch_cuda = types.ModuleType("torch.cuda")
+    torchvision_mod = types.ModuleType("torchvision")
+    torchvision_transforms = types.ModuleType("torchvision.transforms")
+
+    class FakeTensor:
+        def __init__(self, data):
+            self.data = data
+            self._shape = self._infer_shape(data)
+
+        @property
+        def shape(self):
+            return self._shape
+
+        @property
+        def ndim(self):
+            return len(self._shape)
+
+        @property
+        def dtype(self):
+            return type(self._first_scalar(self.data))
+
+        @property
+        def device(self):
+            return "cpu"
+
+        def new_full(self, shape, fill_value):
+            return FakeTensor(self._filled(shape, fill_value))
+
+        def __setitem__(self, key, value):
+            self._assign(self.data, key, value.data)
+
+        def __getitem__(self, key):
+            return FakeTensor(self.data[key])
+
+        def to(self, *_, **__):
+            return self
+
+        def squeeze(self, dim=None):
+            return self
+
+        @classmethod
+        def _infer_shape(cls, data):
+            if isinstance(data, list):
+                return (len(data),) + (cls._infer_shape(data[0]) if data else ())
+            return ()
+
+        @classmethod
+        def _filled(cls, shape, fill_value):
+            if not shape:
+                return fill_value
+            return [cls._filled(shape[1:], fill_value) for _ in range(shape[0])]
+
+        @classmethod
+        def _first_scalar(cls, data):
+            return cls._first_scalar(data[0]) if isinstance(data, list) else data
+
+        @classmethod
+        def _assign(cls, target, slices, source):
+            if len(slices) == 1:
+                for i, value in enumerate(source):
+                    target[i] = value
+                return
+            for i, child in enumerate(source):
+                cls._assign(target[i], slices[1:], child)
+
+    def fake_stack(values, dim=0):
+        assert dim == 0
+        return FakeTensor([value.data for value in values])
+
+    def fake_default_collate(batch):
+        first = batch[0]
+        if isinstance(first, FakeTensor):
+            shapes = [item.shape for item in batch]
+            if any(shape != shapes[0] for shape in shapes[1:]):
+                raise RuntimeError("variable tensor shapes cannot be default-collated")
+            return fake_stack(batch, dim=0)
+        if isinstance(first, dict):
+            return {key: fake_default_collate([item[key] for item in batch]) for key in first}
+        return list(batch)
+
+    class _DummyModule:
+        def __init__(self, *_, **__):
+            pass
+
+        def __call__(self, *args, **kwargs):
+            return self.forward(*args, **kwargs)
+
+        def forward(self, *args, **__):
+            return args[0] if args else None
+
+        def to(self, *_, **__):
+            return self
+
+        def eval(self):
+            return self
+
+    torch_mod.FakeTensor = FakeTensor
+    torch_mod.is_tensor = lambda value: isinstance(value, FakeTensor)
+    torch_mod.stack = fake_stack
+    torch_mod.no_grad = lambda fn=None: (fn if fn is not None else (lambda func: func))
+    torch_mod.inference_mode = torch_mod.no_grad
+    torch_mod.float16 = "float16"
+    torch_mod.float32 = "float32"
+    torch_mod.Tensor = FakeTensor
+    torch_nn.Module = _DummyModule
+    for name in ("Sequential", "Linear", "SiLU", "Dropout1d", "Dropout", "ReLU"):
+        setattr(torch_nn, name, _DummyModule)
+    torch_cuda.is_available = lambda: False
+    torch_utils_data.DataLoader = object
+    torch_utils_data.IterableDataset = object
+    torch_utils_data.get_worker_info = lambda: None
+    torch_utils_data_utils.collate = torch_utils_data_utils_collate
+    torch_utils_data_utils_collate.default_collate = fake_default_collate
+    torchvision_mod.transforms = torchvision_transforms
+
+    dummy_modules.update({
+        "torch": torch_mod,
+        "torch.nn": torch_nn,
+        "torch.cuda": torch_cuda,
+        "torch.utils": torch_utils,
+        "torch.utils.data": torch_utils_data,
+        "torch.utils.data._utils": torch_utils_data_utils,
+        "torch.utils.data._utils.collate": torch_utils_data_utils_collate,
+        "torchvision": torchvision_mod,
+        "torchvision.transforms": torchvision_transforms,
+    })
+    dummy_modules["onnxruntime"].InferenceSession = object
+    sys.modules.update(dummy_modules)
+
+
+_install_dummy_modules()
+
+import create_index
+from create_index import QwenVlEmbeddingBackend, safe_collate
+
+
+class QwenCollateTests(unittest.TestCase):
+    def test_qwen_processor_dicts_are_padded_before_encoding(self):
+        tensor = create_index.torch.FakeTensor
+        samples = [
+            ({"pixel_values": tensor([[1, 2], [3, 4]]), "image_grid_thw": tensor([[1, 1, 2]])}, None, 0, tensor([1]), tensor([2])),
+            ({"pixel_values": tensor([[5, 6], [7, 8], [9, 10]]), "image_grid_thw": tensor([[1, 1, 3]])}, None, 1, tensor([3]), tensor([4])),
+        ]
+
+        search_batch, _, _, _, _ = safe_collate(samples)
+
+        self.assertEqual(search_batch["pixel_values"].shape, (2, 3, 2))
+        self.assertEqual(search_batch["pixel_values"].data[0][2], [0, 0])
+
+        backend = QwenVlEmbeddingBackend.__new__(QwenVlEmbeddingBackend)
+        backend.device = "cpu"
+        backend.output_dim = None
+        seen = {}
+
+        class FakeModel:
+            def __call__(self, **kwargs):
+                seen.update(kwargs)
+                return types.SimpleNamespace(pooler_output=tensor([[1.0], [2.0]]))
+
+        backend.model = FakeModel()
+        internal, features = backend.encode_image_with_internal(search_batch)
+
+        self.assertIs(internal, features)
+        self.assertEqual(features.shape, (2, 1))
+        self.assertEqual(seen["pixel_values"].shape, (2, 3, 2))
+
+    def test_openclip_tensor_inputs_stay_on_default_collate_path(self):
+        tensor = create_index.torch.FakeTensor
+        samples = [
+            (tensor([[1, 2], [3, 4]]), None, 0, tensor([1]), tensor([2])),
+            (tensor([[5, 6], [7, 8]]), None, 1, tensor([3]), tensor([4])),
+        ]
+
+        search_batch, _, _, _, _ = safe_collate(samples)
+
+        self.assertEqual(search_batch.shape, (2, 2, 2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Qwen processor outputs can contain per-image tensor fields (e.g. `pixel_values`, `image_grid_thw`) with variable-length sequence dimensions that cannot be safely `default_collate`-stacked across a batch. 
- Collating those dictionaries without padding can break batched encoding with `QwenVlEmbeddingBackend` or cause inconsistent shapes at runtime.

### Description
- Added Qwen-aware collation helpers: `QWEN_VARIABLE_IMAGE_KEYS`, `_tensor_shapes_differ`, `_is_variable_length_qwen_inputs`, `_pad_tensors_to_common_shape`, `_collate_qwen_processor_inputs`, and `_collate_search_inputs` to detect and pad variable-length processor dicts before stacking. 
- Updated `safe_collate` to route search inputs through `_collate_search_inputs` so Qwen processor dicts get padded per-batch while regular OpenCLIP tensor inputs still use `default_collate`. 
- Padding logic pads tensor fields to the per-dimension maximum shape across the batch and then stacks them, preserving non-tensor fields via `default_collate`.
- Added `tests/test_qwen_collate.py` with lightweight runtime stubs that exercises two cases: padding of variable-length Qwen-processor dicts and ensuring plain tensor inputs still follow the default-collate path.

### Testing
- Ran the new unit test with `python -m unittest tests.test_qwen_collate`, and it passed (`OK`).
- Attempted to run `python -m unittest tests.test_qwen_collate tests.test_tagger tests.test_usecase_result_sorting`, which failed due to an unrelated pre-existing `SyntaxError` (conflict markers) in `app/application/usecase.py`; that failure is external to the collation changes and tests for the new behavior remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32fbf4a0048324bf92117af7f8a98e)