### PR TITLE
Fix search_random merge conflict and use dynamic embedding dimension

### DIFF
--- a/app/application/usecase.py
+++ b/app/application/usecase.py
@@ -531,12 +531,6 @@ class Usecase:
     ) -> ResultImageItemList:
         """乱数から検索する"""
 
-<<<<<<< HEAD
-        # 単位超球面（Unit hypersphere）上から一様にベクトルをサンプリング
-        features: np.ndarray = np.random.normal(0, 1, [1, 768]).astype(np.float32)
-
-=======
->>>>>>> a58619967598e25cec1f80703a15249ed73521b8
         # indexを読み込み
         index, item_list = self._get_index_and_items(model_id, aesthetic_model_name)
         mean_vector = self._accessor.get_mean_meta_vector(model_id)


### PR DESCRIPTION
### Motivation
- Remove unresolved merge conflict markers in `Usecase.search_random` and ensure random feature vector generation uses the actual index dimension instead of a hard-coded 768.

### Description
- Deleted the conflict markers and the fixed `[1, 768]` random vector generation and kept the `[1, dimension]` generation placed after calling `self._get_index_and_items(...)`, `self._accessor.get_mean_meta_vector(...)`, and `_get_index_dimension(...)`.

### Testing
- Ran `python -m py_compile app/application/usecase.py` which completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32ff4f70b48324b05a33c1c724bdfd)