### PR TITLE
Handle PIL image batches in safe_collate

### DIFF
--- a/create_index.py
+++ b/create_index.py
@@ -111,7 +111,15 @@ def _collate_qwen_processor_inputs(search_inputs: list[dict[str, Any]]) -> dict[
 def _collate_search_inputs(search_inputs: list[Any]):
     if _is_variable_length_qwen_inputs(search_inputs):
         return _collate_qwen_processor_inputs(search_inputs)
+    if search_inputs and all(isinstance(item, Image.Image) for item in search_inputs):
+        return search_inputs
     return default_collate(search_inputs)
+
+
+def _collate_optional(values: list[Any]):
+    if all(value is None for value in values):
+        return None
+    return default_collate(values)
 
 
 def safe_collate(batch):

--- a/tests/test_qwen_collate.py
+++ b/tests/test_qwen_collate.py
@@ -12,8 +12,11 @@ def _install_dummy_modules():
     pil_mod = types.ModuleType("PIL")
     pil_image_mod = types.ModuleType("PIL.Image")
     pil_image_file_mod = types.ModuleType("PIL.ImageFile")
+    class FakePilImage:
+        pass
+
     pil_image_mod.MAX_IMAGE_PIXELS = None
-    pil_image_mod.Image = object
+    pil_image_mod.Image = FakePilImage
     pil_image_mod.LANCZOS = 1
     pil_mod.Image = pil_image_mod
     pil_mod.ImageFile = pil_image_file_mod
@@ -108,6 +111,8 @@ def _install_dummy_modules():
 
     def fake_default_collate(batch):
         first = batch[0]
+        if isinstance(first, FakePilImage):
+            raise AssertionError("PIL images should bypass default_collate")
         if isinstance(first, FakeTensor):
             shapes = [item.shape for item in batch]
             if any(shape != shapes[0] for shape in shapes[1:]):
@@ -202,6 +207,21 @@ class QwenCollateTests(unittest.TestCase):
         self.assertIs(internal, features)
         self.assertEqual(features.shape, (2, 1))
         self.assertEqual(seen["pixel_values"].shape, (2, 3, 2))
+
+
+    def test_pil_image_inputs_bypass_default_collate(self):
+        tensor = create_index.torch.FakeTensor
+        images = [create_index.Image.Image(), create_index.Image.Image()]
+        samples = [
+            (images[0], None, 0, tensor([1]), tensor([2])),
+            (images[1], None, 1, tensor([3]), tensor([4])),
+        ]
+
+        search_batch, _, _, _, _ = safe_collate(samples)
+
+        self.assertIsInstance(search_batch, list)
+        self.assertEqual(search_batch, images)
+        self.assertTrue(all(isinstance(item, create_index.Image.Image) for item in search_batch))
 
     def test_openclip_tensor_inputs_stay_on_default_collate_path(self):
         tensor = create_index.torch.FakeTensor


### PR DESCRIPTION
### Motivation
- Allow image-feature extraction to receive a list of `PIL.Image.Image` objects unchanged so downstream image processors can call `processor(images=..., padding=True, return_tensors="pt")` without `default_collate` converting images into tensors first.

### Description
- In `_collate_search_inputs` keep the existing Qwen variable-dict handling first and then return `search_inputs` unchanged when it is non-empty and every item is an instance of `Image.Image` so images bypass `default_collate`.
- Add `_collate_optional(values: list[Any])` which returns `None` when all inputs are `None` and otherwise delegates to `default_collate` for optional fields used by `safe_collate`.
- Update `tests/test_qwen_collate.py` to provide a `FakePilImage` in the test fixture, make `fake_default_collate` assert if a PIL image reaches it, and add `test_pil_image_inputs_bypass_default_collate` which constructs samples shaped like `(PIL_image, None, idx, wd_arr, z3d_arr)` and asserts `safe_collate(samples)[0]` remains the list of PIL images.

### Testing
- Ran `python -m unittest tests/test_qwen_collate.py`, which passed (3 tests passed).
- Ran `python -m pytest tests/test_qwen_collate.py`, which also passed (3 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a330038b8d88324b5c985725c908145)