### PR TITLE
Include chat prompt tokens for Qwen image batches

### DIFF
--- a/create_index.py
+++ b/create_index.py
@@ -1306,6 +1306,42 @@ class QwenVlEmbeddingBackend(SearchEmbeddingBackend):
     def preprocess(self):
         return QwenVlImagePreprocess()
 
+    def prepare_image_inputs(self, images: list[Image.Image]) -> dict[str, Any]:
+        """Build Qwen3-VL image embedding inputs with required prompt tokens."""
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "Represent this image for retrieval."},
+                ],
+            }
+        ]
+        if hasattr(self.processor, "apply_chat_template"):
+            prompt = self.processor.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=False,
+            )
+        else:
+            prompt = "<|vision_start|><|image_pad|><|vision_end|>Represent this image for retrieval."
+
+        inputs = self.processor(
+            text=[prompt] * len(images),
+            images=images,
+            padding=True,
+            return_tensors="pt",
+        )
+        if "input_ids" not in inputs and "inputs_embeds" not in inputs:
+            raise RuntimeError(
+                "Qwen VL image preprocessing must include text/chat prompt tokens "
+                "(`input_ids` or `inputs_embeds`)."
+            )
+        if not any(key in inputs for key in QWEN_VARIABLE_IMAGE_KEYS):
+            raise RuntimeError("Qwen VL image preprocessing did not return image tensors.")
+        return inputs
+
     def _move_inputs_to_device(self, inputs):
         if isinstance(inputs, dict):
             return {
@@ -1630,11 +1666,7 @@ def extract_image_features(
                 and batched_image_input
                 and isinstance(batched_image_input[0], Image.Image)
             ):
-                batched_image_input = search_model.processor(
-                    images=batched_image_input,
-                    padding=True,
-                    return_tensors="pt",
-                )
+                batched_image_input = search_model.prepare_image_inputs(batched_image_input)
 
             batched_image_input = _to_device(batched_image_input, device)
             batched_metadata_input = _to_device(batched_metadata_input, device)

--- a/tests/test_qwen_collate.py
+++ b/tests/test_qwen_collate.py
@@ -182,8 +182,8 @@ class QwenCollateTests(unittest.TestCase):
     def test_qwen_processor_dicts_are_padded_before_encoding(self):
         tensor = create_index.torch.FakeTensor
         samples = [
-            ({"pixel_values": tensor([[1, 2], [3, 4]]), "image_grid_thw": tensor([[1, 1, 2]])}, None, 0, tensor([1]), tensor([2])),
-            ({"pixel_values": tensor([[5, 6], [7, 8], [9, 10]]), "image_grid_thw": tensor([[1, 1, 3]])}, None, 1, tensor([3]), tensor([4])),
+            ({"input_ids": tensor([101, 102]), "attention_mask": tensor([1, 1]), "pixel_values": tensor([[1, 2], [3, 4]]), "image_grid_thw": tensor([[1, 1, 2]])}, None, 0, tensor([1]), tensor([2])),
+            ({"input_ids": tensor([101, 103]), "attention_mask": tensor([1, 1]), "pixel_values": tensor([[5, 6], [7, 8], [9, 10]]), "image_grid_thw": tensor([[1, 1, 3]])}, None, 1, tensor([3]), tensor([4])),
         ]
 
         search_batch, _, _, _, _ = safe_collate(samples)
@@ -206,8 +206,41 @@ class QwenCollateTests(unittest.TestCase):
 
         self.assertIs(internal, features)
         self.assertEqual(features.shape, (2, 1))
+        self.assertEqual(seen["input_ids"].shape, (2, 2))
         self.assertEqual(seen["pixel_values"].shape, (2, 3, 2))
 
+    def test_prepare_image_inputs_adds_prompt_tokens_and_images(self):
+        tensor = create_index.torch.FakeTensor
+        images = [create_index.Image.Image(), create_index.Image.Image()]
+        calls = {}
+
+        class FakeProcessor:
+            def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+                calls["messages"] = messages
+                calls["tokenize"] = tokenize
+                calls["add_generation_prompt"] = add_generation_prompt
+                return "<chat><image>Represent this image for retrieval."
+
+            def __call__(self, **kwargs):
+                calls["processor_kwargs"] = kwargs
+                return {
+                    "input_ids": tensor([[1, 2], [1, 2]]),
+                    "attention_mask": tensor([[1, 1], [1, 1]]),
+                    "pixel_values": tensor([[3, 4], [5, 6]]),
+                    "image_grid_thw": tensor([[1, 1, 2], [1, 1, 2]]),
+                }
+
+        backend = QwenVlEmbeddingBackend.__new__(QwenVlEmbeddingBackend)
+        backend.processor = FakeProcessor()
+
+        inputs = backend.prepare_image_inputs(images)
+
+        self.assertIn("input_ids", inputs)
+        self.assertIn("pixel_values", inputs)
+        self.assertEqual(calls["processor_kwargs"]["images"], images)
+        self.assertEqual(calls["processor_kwargs"]["text"], ["<chat><image>Represent this image for retrieval."] * 2)
+        self.assertFalse(calls["tokenize"])
+        self.assertFalse(calls["add_generation_prompt"])
 
     def test_pil_image_inputs_bypass_default_collate(self):
         tensor = create_index.torch.FakeTensor


### PR DESCRIPTION
### Motivation
- Qwen3-VL embedding expects a multimodal input that includes prompt tokens plus image tensors, but the prior image-only processor call omitted the required text/chat tokens causing model input mismatch. 
- The change ensures image batches sent to the Qwen encoder are in the processor’s expected multimodal format while leaving OpenCLIP behavior unchanged.

### Description
- Add `QwenVlEmbeddingBackend.prepare_image_inputs(images: list[Image.Image])` which builds a minimal retrieval chat prompt (using `processor.apply_chat_template` when available), calls the processor with both `text` and `images`, and validates that the returned dict contains `input_ids` or `inputs_embeds` and image tensor keys. 
- Replace the previous image-only `processor(images=..., return_tensors="pt")` call in `extract_image_features()` with `search_model.prepare_image_inputs(...)`. 
- Update tests in `tests/test_qwen_collate.py` to include token keys in fake Qwen batches and add `test_prepare_image_inputs_adds_prompt_tokens_and_images` to assert the processor receives both repeated prompt text and the original images. 
- No changes were made to the OpenCLIP backend path or behavior.

### Testing
- Ran unit tests with `python -m unittest tests.test_qwen_collate` and all tests passed (`Ran 4 tests ... OK`).
- Verified Python syntax compilation with `python -m py_compile create_index.py tests/test_qwen_collate.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33038b51988324bdfd50315300d47e)