### PR TITLE
Separate OpenCLIP metadata feature spaces for style clustering

### DIFF
--- a/create_index.py
+++ b/create_index.py
@@ -488,9 +488,39 @@ class StyleCluster:
         except Exception as e:
             print(f"Failed to load style cluster centers: {e}")
 
+    def _prepare_style_features(self, features: torch.Tensor | np.ndarray, *, batched: bool):
+        if not torch.is_tensor(features):
+            features = torch.from_numpy(features)
+
+        expected_ndim = 2 if batched else 1
+        if features.ndim != expected_ndim:
+            shape_label = "(N, D)" if batched else "(D,)"
+            raise ValueError(
+                f"Style features must have shape {shape_label}, "
+                f"got {tuple(features.shape)}"
+            )
+
+        expected_dim = int(self.cluster_centers.shape[1])
+        actual_dim = int(features.shape[1] if batched else features.shape[0])
+        if actual_dim != expected_dim:
+            raise ValueError(
+                "Style feature dimension mismatch: "
+                f"features={actual_dim}, "
+                f"cluster_centers={expected_dim}. "
+                "Use OpenCLIP pre-projection/internal features "
+                "for style clustering."
+            )
+
+        return features.to(
+            device=self.cluster_centers.device,
+            dtype=self.cluster_centers.dtype,
+            non_blocking=True,
+        )
+
     @torch.no_grad()
-    def get_cluster(self, features):
-        """指定されたfeaturesからスタイルクラスタID（文字列）を返す"""
+    def get_cluster(self, features: torch.Tensor | np.ndarray):
+        """指定された単一のstyle features (D,) からスタイルクラスタIDを返す。"""
+        features = self._prepare_style_features(features, batched=False)
         distances = torch.norm(self.cluster_centers - features, dim=1)
         min_index = torch.argmin(distances).item()
         distance = distances[min_index]
@@ -504,10 +534,7 @@ class StyleCluster:
         features: (N, D)
         return: (cluster_id_list, distance_ndarray)
         """
-        if not torch.is_tensor(features):
-            features = torch.from_numpy(features)
-
-        features = features.to(self.device)  # (N,D)
+        features = self._prepare_style_features(features, batched=True)
         # (N, num_centers) の距離行列
         # cdist は多少重いけど、python for で回すより遥かに速い
         distances = torch.cdist(features, self.cluster_centers)  # (N, C)
@@ -1681,24 +1708,61 @@ def extract_image_features(
                 search_denom = search_features_tensor.norm(dim=-1, keepdim=True).clamp_min(1e-12)
                 search_features_tensor = (search_features_tensor / search_denom).contiguous()
 
-                if aesthetic_model is not None and batched_metadata_input is not None:
-                    _metadata_internal_features_tensor, metadata_features_tensor = metadata_model.encode_image_with_internal(
-                        batched_metadata_input
+                batch_size = int(search_features_tensor.shape[0])
+                needs_metadata_features = (
+                    batched_metadata_input is not None
+                    and metadata_model is not None
+                    and (
+                        aesthetic_model is not None
+                        or pony_scorer is not None
+                        or style_cluster is not None
                     )
-                    metadata_denom = metadata_features_tensor.norm(dim=-1, keepdim=True).clamp_min(1e-12)
-                    metadata_features_tensor = (metadata_features_tensor / metadata_denom).contiguous()
-                    aesthetic_dtype = next(aesthetic_model.parameters()).dtype
-                    metadata_features_for_scores = metadata_features_tensor.to(dtype=aesthetic_dtype)
-                    aesthetic_scores = aesthetic_model.score_batch(metadata_features_for_scores).squeeze(-1).cpu().numpy()
-                    pony_scores = pony_scorer.score_batch(metadata_features_for_scores)
-                    cluster_ids, _cluster_dists = style_cluster.get_cluster_batch(
-                        metadata_features_for_scores
-                    )
-                else:
-                    batch_size = int(search_features_tensor.shape[0])
-                    aesthetic_scores = [None] * batch_size
-                    pony_scores = [None] * batch_size
-                    cluster_ids = [None] * batch_size
+                )
+                aesthetic_scores = [None] * batch_size
+                pony_scores = [None] * batch_size
+                cluster_ids = [None] * batch_size
+
+                if needs_metadata_features:
+                    (
+                        metadata_internal_features_tensor,
+                        metadata_projected_features_tensor,
+                    ) = metadata_model.encode_image_with_internal(batched_metadata_input)
+
+                    metadata_features_for_scores = None
+                    if aesthetic_model is not None or pony_scorer is not None:
+                        # Projected OpenCLIP features are used by aesthetic/Pony scorers.
+                        projected_norm = metadata_projected_features_tensor.norm(
+                            dim=-1,
+                            keepdim=True,
+                        ).clamp_min(1e-12)
+                        metadata_features_for_scores = (
+                            metadata_projected_features_tensor / projected_norm
+                        ).contiguous()
+
+                    if aesthetic_model is not None:
+                        aesthetic_dtype = next(aesthetic_model.parameters()).dtype
+                        aesthetic_features = metadata_features_for_scores.to(dtype=aesthetic_dtype)
+                        aesthetic_scores = (
+                            aesthetic_model
+                            .score_batch(aesthetic_features)
+                            .squeeze(-1)
+                            .cpu()
+                            .numpy()
+                        )
+
+                    if pony_scorer is not None:
+                        pony_scores = pony_scorer.score_batch(metadata_features_for_scores)
+
+                    if style_cluster is not None:
+                        # Pre-projection/internal OpenCLIP features are used for style clustering.
+                        style_features = metadata_internal_features_tensor.to(
+                            device=style_cluster.cluster_centers.device,
+                            dtype=style_cluster.cluster_centers.dtype,
+                            non_blocking=True,
+                        )
+                        cluster_ids, _cluster_dists = style_cluster.get_cluster_batch(
+                            style_features
+                        )
 
                 # 3) タグ付けもバッチで
                 if args.use_existing_tags:

--- a/tests/test_create_index_feature_routing.py
+++ b/tests/test_create_index_feature_routing.py
@@ -1,0 +1,196 @@
+import sqlite3
+import sys
+import types
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from test_qwen_collate import _install_dummy_modules  # noqa: E402
+
+_install_dummy_modules()
+
+import create_index  # noqa: E402
+
+torch = create_index.torch
+
+
+def _patch_fake_tensor():
+    FakeTensor = torch.FakeTensor
+
+    def _rows(shape, fill=0.0):
+        if len(shape) == 1:
+            return [fill for _ in range(shape[0])]
+        return [_rows(shape[1:], fill) for _ in range(shape[0])]
+
+    def zeros(*shape, dtype=None, **kwargs):
+        if len(shape) == 1 and isinstance(shape[0], (tuple, list)):
+            shape = tuple(shape[0])
+        return FakeTensor(_rows(shape, 0.0))
+
+    def ones(*shape, dtype=None, **kwargs):
+        if len(shape) == 1 and isinstance(shape[0], (tuple, list)):
+            shape = tuple(shape[0])
+        return FakeTensor(_rows(shape, 1.0))
+
+    def arange(n):
+        return FakeTensor(list(range(n)))
+
+    def norm(self, dim=None, keepdim=False):
+        if dim in (-1, 1) and self.ndim == 2:
+            data = [[1.0] for _ in range(self.shape[0])] if keepdim else [1.0 for _ in range(self.shape[0])]
+            return FakeTensor(data)
+        return FakeTensor([1.0])
+
+    def tobytes(self):
+        return b"x" * (4 * self.shape[0])
+
+    def min_method(self, dim=None):
+        if dim == 1:
+            return FakeTensor([0.0 for _ in range(self.shape[0])]), FakeTensor([0 for _ in range(self.shape[0])])
+        return FakeTensor([0.0]), FakeTensor([0])
+
+    FakeTensor.norm = norm
+    FakeTensor.clamp_min = lambda self, value: self
+    FakeTensor.__truediv__ = lambda self, other: self
+    FakeTensor.contiguous = lambda self: self
+    FakeTensor.cpu = lambda self: self
+    FakeTensor.float = lambda self: self
+    FakeTensor.detach = lambda self: self
+    FakeTensor.numpy = lambda self: self
+    FakeTensor.tolist = lambda self: self.data
+    FakeTensor.__iter__ = lambda self: (FakeTensor(item) for item in self.data)
+    FakeTensor.tobytes = tobytes
+    FakeTensor.__len__ = lambda self: self.shape[0]
+    FakeTensor.__int__ = lambda self: int(self.data)
+    FakeTensor.__float__ = lambda self: float(self.data)
+    FakeTensor.min = min_method
+    torch.zeros = zeros
+    torch.ones = ones
+    torch.arange = arange
+    torch.from_numpy = lambda value: FakeTensor(value)
+    torch.cdist = lambda features, centers: zeros(features.shape[0], centers.shape[0])
+
+    class _NoGrad:
+        def __call__(self, fn=None):
+            return self if fn is None else fn
+        def __enter__(self):
+            return None
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    torch.no_grad = _NoGrad()
+    torch.inference_mode = _NoGrad()
+
+
+_patch_fake_tensor()
+
+
+class _SearchModel:
+    def encode_image_with_internal(self, image_input):
+        features = torch.ones(image_input.shape[0], 4)
+        return features, features
+
+
+class _MetadataModel:
+    def encode_image_with_internal(self, metadata_input):
+        return torch.ones(metadata_input.shape[0], 1024), torch.ones(metadata_input.shape[0], 768)
+
+
+class _AestheticModel:
+    def __init__(self):
+        self.param = types.SimpleNamespace(dtype=torch.float32)
+        self.seen_shape = None
+
+    def parameters(self):
+        return iter([self.param])
+
+    def score_batch(self, features):
+        self.seen_shape = tuple(features.shape)
+        return torch.zeros(features.shape[0], 1)
+
+
+class _PonyScorer:
+    def __init__(self):
+        self.seen_shape = None
+
+    def score_batch(self, features):
+        self.seen_shape = tuple(features.shape)
+        return [0.25] * features.shape[0]
+
+
+class _StyleCluster:
+    def __init__(self):
+        self.cluster_centers = torch.zeros(2048, 1024)
+        self.seen_shape = None
+
+    def get_cluster_batch(self, features):
+        self.seen_shape = tuple(features.shape)
+        return [7] * features.shape[0], [0.0] * features.shape[0]
+
+
+class _TaggingService:
+    def tag_batch(self, wd_batch, z3d_batch):
+        return [{"rating": "general", "tags": ["tag"]} for _ in range(len(wd_batch))]
+
+
+class FeatureRoutingTests(unittest.TestCase):
+    def test_extract_image_features_routes_metadata_feature_spaces_separately(self):
+        con = sqlite3.connect(":memory:")
+        cur = con.cursor()
+        cur.execute("""
+            CREATE TABLE image_meta (
+                image_id TEXT PRIMARY KEY, image_path TEXT, meta BLOB,
+                aesthetic_quality REAL, pony_aesthetic_quality REAL,
+                style_cluster TEXT, rating TEXT, image_tags TEXT,
+                time_stamp_ISO TEXT, search_embedding_model TEXT,
+                metadata_embedding_model TEXT)
+        """)
+        args = types.SimpleNamespace(
+            batch_size=3, search_model_out_dim=None, use_existing_tags=False,
+            image_dir=".", search_backend="qwen3_vl", search_model_id="fake-qwen",
+            disable_clip_metadata=False,
+        )
+        batch_size = 3
+        loader = [(torch.zeros(batch_size, 1), torch.zeros(batch_size, 1), torch.arange(batch_size), torch.zeros(batch_size, 1), torch.zeros(batch_size, 1))]
+        aesthetic_model = _AestheticModel()
+        pony_scorer = _PonyScorer()
+        style_cluster = _StyleCluster()
+        old_tqdm = getattr(create_index.tqdm, "tqdm", None)
+        create_index.tqdm.tqdm = lambda iterable, total=None: iterable
+        try:
+            create_index.extract_image_features(
+                args, "cpu", _SearchModel(), con, cur, loader,
+                [f"image-{i}.png" for i in range(batch_size)],
+                [f"id-{i}" for i in range(batch_size)],
+                aesthetic_model, pony_scorer, style_cluster, _TaggingService(),
+                metadata_model=_MetadataModel(),
+            )
+        finally:
+            if old_tqdm is None:
+                delattr(create_index.tqdm, "tqdm")
+            else:
+                create_index.tqdm.tqdm = old_tqdm
+
+        self.assertEqual(aesthetic_model.seen_shape, (batch_size, 768))
+        self.assertEqual(pony_scorer.seen_shape, (batch_size, 768))
+        self.assertEqual(style_cluster.seen_shape, (batch_size, 1024))
+        self.assertEqual(cur.execute("SELECT COUNT(*) FROM image_meta").fetchone()[0], batch_size)
+
+    def test_style_cluster_dimension_mismatch_has_clear_error(self):
+        cluster = create_index.StyleCluster.__new__(create_index.StyleCluster)
+        cluster.cluster_centers = torch.zeros(2048, 1024)
+        cluster.kept_cluster_indices = list(range(2048))
+        with self.assertRaisesRegex(ValueError, r"features=768.*cluster_centers=1024"):
+            cluster.get_cluster_batch(torch.zeros(2, 768))
+
+    def test_style_cluster_batch_converts_dtype_before_cdist_on_cpu(self):
+        cluster = create_index.StyleCluster.__new__(create_index.StyleCluster)
+        cluster.cluster_centers = torch.zeros(2, 4)
+        cluster.kept_cluster_indices = [10, 11]
+        cluster_ids, distances = cluster.get_cluster_batch(torch.ones(3, 4))
+        self.assertEqual(cluster_ids, [10, 10, 10])
+        self.assertEqual(distances.data, [0.0, 0.0, 0.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Fix the runtime error caused by passing 768-d projected OpenCLIP features into style clustering that expects 1024-d internal features.
- Ensure aesthetic and Pony scorers use OpenCLIP projected features while StyleCluster uses pre-projection/internal features so the different feature spaces are not mixed.
- Provide clear validation errors when feature dimensions mismatch so the root cause is obvious instead of a low-level `torch.cdist()` error.

### Description

- Update `extract_image_features()` to unpack `metadata_model.encode_image_with_internal()` into `(internal, projected)` and route the 768-d projected features to `aesthetic_model` and `pony_scorer`, and the internal/pre-projection features to `StyleCluster`, while safely handling any of those components being `None` (file: `create_index.py`).
- Add `StyleCluster._prepare_style_features()` and use it from `get_cluster()` and `get_cluster_batch()` to validate 1-/2-D shapes, check feature dimensionality matches `cluster_centers`, and align `device`/`dtype` before calling `torch.cdist()`; raise a clear `ValueError` on mismatch (file: `create_index.py`).
- Add regression tests `tests/test_create_index_feature_routing.py` that verify correct routing of projected (768-d) vs internal (1024-d) features, that a mismatched-dimension batch raises an informative `ValueError`, and that batch dtype/device conversion is handled before `cdist()` (file: `tests/test_create_index_feature_routing.py`).
- Preserve existing search-embedding handling and avoid any shape-hacking (no padding/truncation/extra linear layers), and avoid extra CPU/GPU transfers beyond necessary dtype/device alignment.

### Testing

- Ran `python -m unittest tests/test_create_index_feature_routing.py` and the new tests passed (OK).
- Ran `python -m unittest tests/test_qwen_collate.py` and those tests passed (OK).
- `python -m unittest discover -s tests` surfaced unrelated failures in the environment test harness because dummy-module setup replaces `PIL.Image` causing tagger tests to error, and `uv sync` / `uv run` failed in this environment due to `onnxruntime-gpu` not having a wheel for CPython 3.14; these are environment/test-harness issues and not regressions in the changes made.
- To run only the new tests locally use: `python -m unittest tests/test_create_index_feature_routing.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a331626936083248ff65d720326d1e1)