### PR TITLE
Accept model ID via params for image_meta and image_ratings; update frontend and add tests

### DIFF
--- a/app/presentation/controller.py
+++ b/app/presentation/controller.py
@@ -1,7 +1,7 @@
 
 import ast
 import logging
-from flask import Flask, request, make_response, send_file
+from flask import Flask, request, make_response, send_file, abort
 
 import pathlib
 import json
@@ -119,40 +119,60 @@ def get_image_item(id: str):
     return from_image_item_to_json(usecase.get_image_item(ImageId(id)))
 
 
-@app.route("/image_meta/<model_name>/<pretrained>/<id>")
-def get_image_metadata(model_name: str, pretrained: str, id: str):
+@app.route("/image_meta/<id>", methods=["GET", "POST"])
+def get_image_metadata(id: str):
     """画像のメタデータ（タグやratingなど）を返す"""
 
-    model_id: ModelId = ModelId(model_name, pretrained)
+    model_id = get_requested_model_id()
     return json.dumps(usecase.get_image_metadata(model_id, ImageId(id)))
 
 
-@app.route("/image_ratings/<model_name>/<pretrained>", methods=["GET", "POST"])
-def get_image_ratings(model_name: str, pretrained: str):
+@app.route("/image_ratings", methods=["GET", "POST"])
+def get_image_ratings():
     """指定された画像IDに限定してrating一覧を返す"""
 
-    model_id: ModelId = ModelId(model_name, pretrained)
+    model_id = get_requested_model_id()
     image_ids = get_requested_image_ids()
     ratings: dict[ImageId, str] = usecase.get_rating_list(model_id, image_ids)
     rating_dict = {image_id.id: rating for image_id, rating in ratings.items()}
     return json.dumps(rating_dict)
 
 
+def get_request_params() -> dict:
+    """query string またはJSON bodyのparamsからAPIパラメータを取り出す"""
+
+    json_obj = request.get_json(silent=True) or {}
+    body_params = json_obj.get("params", json_obj)
+    return body_params if request.method == "POST" else request.args
+
+
+def get_requested_model_id() -> ModelId:
+    """リクエストパラメータから検索モデルIDを取り出す"""
+
+    params = get_request_params()
+    model_name = params.get("model_name")
+    pretrained = params.get("pretrained", "")
+    if model_name is None:
+        abort(400, description="model_name is required")
+    return ModelId(model_name, pretrained or "")
+
+
 def get_requested_image_ids() -> list[ImageId] | None:
     """rating取得リクエストから対象画像IDリストを取り出す"""
 
+    params = get_request_params()
     if request.method == "POST":
-        json_obj = request.get_json(silent=True) or {}
-        params = json_obj.get("params", {})
         id_text_list = params.get("id") or params.get("ids")
     else:
         id_text_list = request.args.getlist("id") or request.args.getlist("ids")
         if not id_text_list:
-            ids_text = request.args.get("ids")
+            ids_text = params.get("ids")
             id_text_list = ids_text.split(",") if ids_text else None
 
     if id_text_list is None:
         return None
+    if isinstance(id_text_list, str):
+        id_text_list = [id_text_list]
 
     return [ImageId(item_id) for item_id in id_text_list if item_id]
 

--- a/app/presentation/view/js/modules/repository.js
+++ b/app/presentation/view/js/modules/repository.js
@@ -73,7 +73,12 @@ export async function getItem(itemId) {
 
 export async function getImageMetadata(modelName, pretrained, itemId) {
 
-    return axios.get(`/image_meta/${modelName}/${pretrained}/${itemId}`).then(res => res.data)
+    return axios.get(`/image_meta/${itemId}`, {
+        params: {
+            model_name: modelName,
+            pretrained: pretrained
+        }
+    }).then(res => res.data)
 }
 
 export async function getImageRatings(modelName, pretrained, itemIds = []) {
@@ -84,11 +89,13 @@ export async function getImageRatings(modelName, pretrained, itemIds = []) {
 
     const payload = {
         params:{
-            id: itemIds
+            model_name: modelName,
+            pretrained: pretrained,
+            ids: itemIds
         }
     }
 
-    return axios.post(`/image_ratings/${modelName}/${pretrained}`, payload).then(res => res.data)
+    return axios.post(`/image_ratings`, payload).then(res => res.data)
 }
 
 

--- a/tests/test_controller_model_params.py
+++ b/tests/test_controller_model_params.py
@@ -1,0 +1,86 @@
+import json
+import unittest
+
+from app.domain.domain_object import ImageId, ModelId
+from app.presentation import controller
+
+
+QWEN_MODEL_NAME = "Qwen/Qwen3-VL-Embedding-2B"
+QWEN_PRETRAINED = ""
+
+
+class FakeUsecase:
+    def __init__(self):
+        self.metadata_calls = []
+        self.rating_calls = []
+
+    def get_image_metadata(self, model_id: ModelId, image_id: ImageId):
+        self.metadata_calls.append((model_id, image_id))
+        return {
+            "tags": "qwen tag",
+            "style_cluster": "cluster-a",
+            "rating": "safe",
+            "aesthetic_quality": 7.5,
+        }
+
+    def get_rating_list(self, model_id: ModelId, image_ids: list[ImageId] | None = None):
+        self.rating_calls.append((model_id, image_ids))
+        ids = image_ids or [ImageId("fallback")]
+        return {image_id: f"rating-{image_id.id}" for image_id in ids}
+
+
+class ControllerModelParamTests(unittest.TestCase):
+    def setUp(self):
+        self.usecase = FakeUsecase()
+        controller.usecase = self.usecase
+        self.client = controller.app.test_client()
+
+    def test_image_meta_accepts_qwen_model_id_from_query_string(self):
+        response = self.client.get(
+            "/image_meta/image-001",
+            query_string={
+                "model_name": QWEN_MODEL_NAME,
+                "pretrained": QWEN_PRETRAINED,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.data), {
+            "tags": "qwen tag",
+            "style_cluster": "cluster-a",
+            "rating": "safe",
+            "aesthetic_quality": 7.5,
+        })
+        self.assertEqual(
+            self.usecase.metadata_calls,
+            [(ModelId(QWEN_MODEL_NAME, QWEN_PRETRAINED), ImageId("image-001"))],
+        )
+
+    def test_image_ratings_accepts_qwen_model_id_and_ids_from_post_params(self):
+        response = self.client.post(
+            "/image_ratings",
+            json={
+                "params": {
+                    "model_name": QWEN_MODEL_NAME,
+                    "pretrained": QWEN_PRETRAINED,
+                    "ids": ["image-001", "image-002"],
+                }
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.data), {
+            "image-001": "rating-image-001",
+            "image-002": "rating-image-002",
+        })
+        self.assertEqual(
+            self.usecase.rating_calls,
+            [(
+                ModelId(QWEN_MODEL_NAME, QWEN_PRETRAINED),
+                [ImageId("image-001"), ImageId("image-002")],
+            )],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- モデルIDをパスセグメントで渡す設計を廃止し、API 呼び出し側が `model_name` と `pretrained` をクエリ文字列または JSON body の `params` で指定できるようにして API 形状を簡潔にするため。 
- フロントエンドの `getImageMetadata()` / `getImageRatings()` を新しい API 仕様に合わせて統一するため。 

### Description

- エンドポイントを `@app.route("/image_meta/<id>")` と `@app.route("/image_ratings")` に変更し、`get_request_params()` と `get_requested_model_id()` を追加してクエリ文字列または POST body の `params` から `model_name`/`pretrained` を取得するように実装を差し替えた (`app/presentation/controller.py`)。 
- `get_requested_image_ids()` を修正して POST body `params` 内の `id`/`ids` とクエリ文字列の両方を正しく解釈するようにした (`app/presentation/controller.py`)。 
- フロントエンド `repository.js` の `getImageMetadata()` を `GET /image_meta/<id>` にクエリで `model_name`/`pretrained` を付与する形に変更し、`getImageRatings()` を `POST /image_ratings` の `params` に `model_name`/`pretrained`/`ids` を入れる形に変更した (`app/presentation/view/js/modules/repository.js`)。 
- `model_name: "Qwen/Qwen3-VL-Embedding-2B", pretrained: ""` での挙動を確認するコントローラ単体テストを追加した (`tests/test_controller_model_params.py`)。 

### Testing

- `tests/test_controller_model_params.py` を `.venv` 環境で実行したところ `OK` だった（`python -m unittest tests.test_controller_model_params`）。 
- `app/presentation/controller.py` の構文チェックは `python -m py_compile app/presentation/controller.py` で成功した。 
- リポジトリ内の全テスト実行（`python -m unittest discover -s tests`）では既存のテスト群により失敗が発生しており、特に `tests/test_qwen_collate.py` がグローバルな `PIL` スタブを挿入するため `tests/test_tagger.py` の `PIL.Image.new` が使えずエラーとなっているため現状全体実行は失敗している。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a331663568c83248feae6628e02c032)