### PR TITLE
Treat unknown image IDs as errors; return 404 in controller; skip missing images in ZIP; add tests

### DIFF
--- a/app/application/usecase.py
+++ b/app/application/usecase.py
@@ -740,8 +740,12 @@ class Usecase:
         for image_id_str in tqdm.tqdm(id_list):
             image_id = ImageId(image_id_str)  # ImageId型に変換
             try:
-                image_with_name: tuple[Image, ImageName] = self._repository.load_image(image_id), self._repository.get_image_name(image_id)
-                images_with_names.append(image_with_name)
+                image = self._repository.load_image(image_id)
+                image_name = self._repository.get_image_name(image_id)
+                if image is None:
+                    self._logger.warning("画像IDの読み込み結果がNoneのためスキップ: %s", image_id)
+                    continue
+                images_with_names.append((image, image_name))
             except (ValueError, FileNotFoundError) as e:
                 self._logger.warning("画像IDが無効のためスキップ: %s", e)
 

--- a/app/domain/repository.py
+++ b/app/domain/repository.py
@@ -17,11 +17,19 @@ class Repository(metaclass=ABCMeta):
 
     @abstractmethod
     def load_image(self, image_id: ImageId) -> Image:
+        """画像IDに対応するオリジナル画像を返す。
+
+        未知の画像IDは ``None`` ではなく ``ValueError`` などの明示的な例外で表現する。
+        """
 
         pass
 
     @abstractmethod
     def load_small_image(self, image_id: ImageId) -> Image:
+        """画像IDに対応する縮小画像を返す。
+
+        未知の画像IDは ``None`` ではなく ``ValueError`` などの明示的な例外で表現する。
+        """
 
         pass
 

--- a/app/infrastructure/local_repository.py
+++ b/app/infrastructure/local_repository.py
@@ -383,7 +383,7 @@ class LocalRepository(Repository):
 
         if relative_path is None:
             self._logger.warning("指定されたImageIdが存在しません: %s", image_id)
-            return None
+            raise ValueError(f"指定されたImageIdが存在しません: {image_id}")
 
         path: pathlib.Path = self._image_dir_path / relative_path
         binary: bytes = path.read_bytes()
@@ -405,7 +405,7 @@ class LocalRepository(Repository):
 
         if relative_path is None:
             self._logger.warning("指定されたImageIdが存在しません: %s", image_id)
-            return None
+            raise ValueError(f"指定されたImageIdが存在しません: {image_id}")
 
         path: pathlib.Path = self._image_dir_path / relative_path
 

--- a/app/presentation/controller.py
+++ b/app/presentation/controller.py
@@ -1,7 +1,7 @@
 
 import ast
 import logging
-from flask import Flask, request, make_response, send_file
+from flask import Flask, request, make_response, send_file, abort
 
 import pathlib
 import json
@@ -161,7 +161,10 @@ def get_requested_image_ids() -> list[ImageId] | None:
 def get_small_image(id: str):
     """画像IDから縮小画像を返す"""
 
-    img = usecase.get_small_image(ImageId(id))
+    try:
+        img = usecase.get_small_image(ImageId(id))
+    except ValueError:
+        abort(404)
     response = make_response(img.binary)
     response.headers.set('Content-Type', img.content_type)
     return response
@@ -171,7 +174,10 @@ def get_small_image(id: str):
 def get_original_image(id: str):
     """画像IDからオリジナル画像を返す"""
 
-    img = usecase.get_image(ImageId(id))
+    try:
+        img = usecase.get_image(ImageId(id))
+    except ValueError:
+        abort(404)
     response = make_response(img.binary)
     response.headers.set('Content-Type', img.content_type)
     return response

--- a/tests/test_missing_image_handling.py
+++ b/tests/test_missing_image_handling.py
@@ -1,0 +1,127 @@
+import sys
+import types
+import unittest
+
+
+def _install_lightweight_stubs():
+    sys.modules.setdefault("faiss", types.ModuleType("faiss"))
+
+    tqdm_stub = types.ModuleType("tqdm")
+    tqdm_stub.tqdm = lambda iterable: iterable
+    sys.modules.setdefault("tqdm", tqdm_stub)
+
+_install_lightweight_stubs()
+
+from app.application.usecase import Usecase
+from app.domain.domain_object import Image, ImageId, ImageName
+
+
+class _Logger:
+    def info(self, *_args, **_kwargs):
+        pass
+
+    def warning(self, *_args, **_kwargs):
+        pass
+
+
+class ZipRepository:
+    def __init__(self):
+        self.created_with = None
+
+    def load_image(self, image_id: ImageId):
+        if image_id.id in {"missing_image", "missing_both"}:
+            raise ValueError("unknown image")
+        if image_id.id == "legacy_none":
+            return None
+        return Image(binary=f"binary:{image_id.id}".encode(), content_type="image/png")
+
+    def get_image_name(self, image_id: ImageId):
+        if image_id.id in {"missing_name", "missing_both"}:
+            raise ValueError("unknown name")
+        return ImageName(f"{image_id.id}.png")
+
+    def create_zip_from_images(self, images_with_names):
+        self.created_with = images_with_names
+        return "zip-buffer"
+
+
+class MissingImageHandlingTests(unittest.TestCase):
+    def test_get_images_zip_skips_ids_when_image_or_name_lookup_fails(self):
+        repository = ZipRepository()
+        usecase = Usecase.__new__(Usecase)
+        usecase._repository = repository
+        usecase._logger = _Logger()
+
+        result = usecase.get_images_zip([
+            "valid_1",
+            "missing_image",
+            "missing_name",
+            "legacy_none",
+            "valid_2",
+        ])
+
+        self.assertEqual(result, "zip-buffer")
+        self.assertEqual(
+            [(image.binary, name.name) for image, name in repository.created_with],
+            [(b"binary:valid_1", "valid_1.png"), (b"binary:valid_2", "valid_2.png")],
+        )
+
+
+def _install_controller_stubs():
+    class AbortException(Exception):
+        def __init__(self, code):
+            self.code = code
+            super().__init__(code)
+
+    class FakeFlask:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def route(self, *_args, **_kwargs):
+            return lambda func: func
+
+    class Headers(dict):
+        def set(self, key, value):
+            self[key] = value
+
+    class Response:
+        def __init__(self, binary):
+            self.binary = binary
+            self.headers = Headers()
+
+    flask_stub = types.ModuleType("flask")
+    flask_stub.Flask = FakeFlask
+    flask_stub.request = types.SimpleNamespace(args={}, form={}, files={})
+    flask_stub.make_response = Response
+    flask_stub.send_file = lambda *args, **kwargs: (args, kwargs)
+    flask_stub.abort = lambda code: (_ for _ in ()).throw(AbortException(code))
+    sys.modules["flask"] = flask_stub
+
+    logging_config_stub = types.ModuleType("app.logging_config")
+    logging_config_stub.configure_logging = lambda: None
+    sys.modules["app.logging_config"] = logging_config_stub
+    return AbortException
+
+
+class ControllerMissingImageTests(unittest.TestCase):
+    def test_unknown_small_and_original_image_return_404(self):
+        AbortException = _install_controller_stubs()
+        sys.modules.pop("app.presentation.controller", None)
+        from app.presentation import controller
+
+        controller.usecase = types.SimpleNamespace(
+            get_small_image=lambda _image_id: (_ for _ in ()).throw(ValueError("unknown")),
+            get_image=lambda _image_id: (_ for _ in ()).throw(ValueError("unknown")),
+        )
+
+        with self.assertRaises(AbortException) as small_error:
+            controller.get_small_image("unknown")
+        self.assertEqual(small_error.exception.code, 404)
+
+        with self.assertRaises(AbortException) as original_error:
+            controller.get_original_image("unknown")
+        self.assertEqual(original_error.exception.code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Ensure repository APIs express unknown image IDs as explicit errors rather than `None` to avoid implicit `None` propagation and subtle failures. 
- Make HTTP behavior consistent by converting repository lookup failures into `404` responses for image endpoints. 
- Prevent `None` or failed lookups from being passed into ZIP creation, and make ZIP creation robust by skipping invalid IDs.

### Description
- Documented the `Repository` contract so `load_image()`/`load_small_image()` return an `Image` and unknown IDs should raise a `ValueError` rather than returning `None` by adding docstrings to `app/domain/repository.py`.
- Changed `LocalRepository.load_image()` and `LocalRepository.load_small_image()` to raise `ValueError` when an `ImageId` is not found instead of returning `None` in `app/infrastructure/local_repository.py`.
- Updated image endpoints in `app/presentation/controller.py` to catch `ValueError` from usecase/repository and call `abort(404)` for both `/image/<id>/small` and `/image/<id>/original`.
- Modified `Usecase.get_images_zip()` to call `load_image()` and `get_image_name()` separately, skip entries when either lookup fails or when `load_image()` inexplicably returns `None`, and only pass valid `(Image, ImageName)` pairs to `create_zip_from_images()` in `app/application/usecase.py`.
- Added `tests/test_missing_image_handling.py` with two tests: one asserting ZIP creation skips invalid IDs and legacy-`None` returns, and one asserting controller endpoints return 404 for unknown IDs.

### Testing
- Ran the new test file with `python -m pytest tests/test_missing_image_handling.py -q` and it passed.
- Ran the full test suite with `python -m pytest -q`; the new tests and most suite tests passed, but two unrelated failures occurred in existing `tests/test_tagger.py` due to the test environment's lightweight `PIL.Image` stubbing lacking `Image.new` (investigation noted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a331667f1fc83249b258d0be30fda1d)