### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/app/presentation/controller.py
+++ b/app/presentation/controller.py
@@ -1,7 +1,7 @@
 
 import ast
 import logging
-from flask import Flask, request, make_response, send_file, abort
+from flask import Flask, request, make_response, send_file, send_from_directory, abort
 
 import pathlib
 import json
@@ -81,16 +81,10 @@ def resource(target: str):
     # ビューの指定をしている。
     pwd = pathlib.Path(__file__).parent
     base_path = (pwd / "view").resolve()
-    full_path = (base_path / target).resolve()
-    if not full_path.is_relative_to(base_path):
-        abort(403)
-    if not full_path.is_file():
-        abort(404)
-    with open(full_path, encoding="UTF-8") as f:
-        text = f.read()
-
-    response = make_response(text)
-    response.headers.set('Content-Type', mimetypes.guess_type(target)[0])
+    response = send_from_directory(str(base_path), target)
+    content_type = mimetypes.guess_type(target)[0]
+    if content_type is not None:
+        response.headers.set('Content-Type', content_type)
     return response
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/ikuto32/MyImageSearch/security/code-scanning/4](https://github.com/ikuto32/MyImageSearch/security/code-scanning/4)

Use Flask’s safe file-serving helper instead of manually opening a path derived from route input.  
Best fix (without changing behavior): in `resource`, replace manual path resolution + `open(...)` with `send_from_directory(base_path, target)`. `send_from_directory` performs safe joining and prevents directory traversal by design, while still serving files from the intended `view` directory.

In `app/presentation/controller.py`:
- Update Flask imports to include `send_from_directory`.
- In `resource`, keep `base_path` computation.
- Replace manual `full_path` checks/open/response creation with:
  - `response = send_from_directory(str(base_path), target)`
  - preserve existing explicit content-type behavior by setting header from `mimetypes.guess_type(target)[0]` when present.

No new external dependency is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
