### PR TITLE
Limit Qwen3-VL input pixels via CLI and processor config

### DIFF
--- a/create_index.py
+++ b/create_index.py
@@ -846,6 +846,15 @@ def get_aesthetic_model(path_to_model, clip_model="vit_l_14"):
     return m
 
 
+def positive_int(value: str) -> int:
+    """Argparse type that accepts only positive integers."""
+
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
 def parse_arguments():
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser()
@@ -888,6 +897,16 @@ def parse_arguments():
         ),
         type=int,
         default=2048,
+    )
+    parser.add_argument(
+        "--qwen-max-pixels",
+        dest="qwen_max_pixels",
+        help=(
+            "Maximum image pixels for Qwen VL preprocessing. Used only with "
+            "--search_backend qwen_vl. Default is 262144 (512x512 equivalent)."
+        ),
+        type=positive_int,
+        default=262144,
     )
 
     parser.add_argument(
@@ -1315,14 +1334,23 @@ class QwenVlImagePreprocess:
 class QwenVlEmbeddingBackend(SearchEmbeddingBackend):
     """Qwen3-VL-Embedding を使う検索エンコーダ。"""
 
-    def __init__(self, model_id: str, device: str, output_dim: int | None = None):
+    def __init__(
+        self,
+        model_id: str,
+        device: str,
+        output_dim: int | None = None,
+        max_pixels: int = 262144,
+    ):
         from transformers import AutoModel, AutoProcessor
 
         self.device = device
         self.model_id = model_id
         self.output_dim = output_dim
+        self.max_pixels = self._validate_max_pixels(max_pixels)
         dtype = torch.float16 if device.startswith("cuda") else torch.float32
         self.processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
+        self.configure_processor_image_limits(self.processor, self.max_pixels)
+        self.print_qwen_processor_config(self.processor)
         self.model = AutoModel.from_pretrained(
             model_id,
             torch_dtype=dtype,
@@ -1330,6 +1358,28 @@ class QwenVlEmbeddingBackend(SearchEmbeddingBackend):
         ).to(device)
         self.model.eval()
         self.print_qwen_runtime_config(self.model)
+
+    @staticmethod
+    def _validate_max_pixels(max_pixels: int) -> int:
+        if not isinstance(max_pixels, int) or isinstance(max_pixels, bool) or max_pixels <= 0:
+            raise ValueError("max_pixels must be a positive integer.")
+        return max_pixels
+
+    @classmethod
+    def configure_processor_image_limits(cls, processor, max_pixels: int) -> None:
+        max_pixels = cls._validate_max_pixels(max_pixels)
+        image_processor = getattr(processor, "image_processor", None)
+        if image_processor is None:
+            raise RuntimeError("Qwen VL processor does not expose image_processor.")
+        image_processor.max_pixels = max_pixels
+        size = getattr(image_processor, "size", None)
+        if isinstance(size, dict) and "longest_edge" in size:
+            size["longest_edge"] = max_pixels
+
+    def print_qwen_processor_config(self, processor) -> None:
+        image_processor = getattr(processor, "image_processor", None)
+        print("processor min_pixels:", getattr(image_processor, "min_pixels", None))
+        print("processor max_pixels:", getattr(image_processor, "max_pixels", None))
 
     def print_qwen_runtime_config(self, model) -> None:
         print("model class:", type(model).__name__)
@@ -1523,7 +1573,12 @@ def load_search_embedding_backend(args, device) -> SearchEmbeddingBackend:
             device,
         )
     if args.search_backend == "qwen_vl":
-        return QwenVlEmbeddingBackend(args.search_model_id, device, args.search_model_out_dim)
+        return QwenVlEmbeddingBackend(
+            args.search_model_id,
+            device,
+            args.search_model_out_dim,
+            max_pixels=args.qwen_max_pixels,
+        )
     raise ValueError(f"Unknown search backend: {args.search_backend}")
 
 

--- a/tests/test_qwen_collate.py
+++ b/tests/test_qwen_collate.py
@@ -280,6 +280,134 @@ class QwenCollateTests(unittest.TestCase):
         self.assertFalse(calls["tokenize"])
         self.assertFalse(calls["add_generation_prompt"])
 
+
+    def test_qwen_backend_configures_processor_max_pixels(self):
+        calls = {}
+
+        class FakeImageProcessor:
+            def __init__(self):
+                self.min_pixels = 3136
+                self.max_pixels = None
+                self.size = {"longest_edge": 999999, "shortest_edge": 28}
+
+        class FakeProcessor:
+            def __init__(self):
+                self.image_processor = FakeImageProcessor()
+
+        fake_processor = FakeProcessor()
+
+        class FakeAutoProcessor:
+            @staticmethod
+            def from_pretrained(model_id, trust_remote_code=True):
+                calls["processor_model_id"] = model_id
+                calls["processor_trust_remote_code"] = trust_remote_code
+                return fake_processor
+
+        class FakeParameter:
+            device = "cpu"
+            dtype = "float32"
+
+        class FakeConfig:
+            _attn_implementation = None
+            use_cache = None
+            text_config = None
+            vision_config = None
+
+        class FakeModel:
+            config = FakeConfig()
+
+            def to(self, device):
+                calls["device"] = device
+                return self
+
+            def eval(self):
+                calls["eval"] = True
+                return self
+
+            def parameters(self):
+                return iter([FakeParameter()])
+
+        class FakeAutoModel:
+            @staticmethod
+            def from_pretrained(model_id, torch_dtype=None, trust_remote_code=True):
+                calls["model_id"] = model_id
+                calls["torch_dtype"] = torch_dtype
+                calls["model_trust_remote_code"] = trust_remote_code
+                return FakeModel()
+
+        transformers_mod = types.ModuleType("transformers")
+        transformers_mod.AutoProcessor = FakeAutoProcessor
+        transformers_mod.AutoModel = FakeAutoModel
+        old_transformers = sys.modules.get("transformers")
+        sys.modules["transformers"] = transformers_mod
+        try:
+            backend = QwenVlEmbeddingBackend("fake-qwen", "cpu", output_dim=128, max_pixels=123456)
+        finally:
+            if old_transformers is None:
+                del sys.modules["transformers"]
+            else:
+                sys.modules["transformers"] = old_transformers
+
+        self.assertIs(backend.processor, fake_processor)
+        self.assertEqual(fake_processor.image_processor.max_pixels, 123456)
+        self.assertEqual(fake_processor.image_processor.size["longest_edge"], 123456)
+        self.assertEqual(fake_processor.image_processor.size["shortest_edge"], 28)
+        self.assertEqual(calls["processor_model_id"], "fake-qwen")
+        self.assertEqual(calls["model_id"], "fake-qwen")
+
+    def test_qwen_max_pixels_cli_default_custom_and_validation(self):
+        original_argv = sys.argv[:]
+        try:
+            sys.argv = ["create_index.py"]
+            args = create_index.parse_arguments()
+            self.assertEqual(args.qwen_max_pixels, 262144)
+
+            sys.argv = ["create_index.py", "--qwen-max-pixels", "131072"]
+            args = create_index.parse_arguments()
+            self.assertEqual(args.qwen_max_pixels, 131072)
+
+            sys.argv = ["create_index.py", "--qwen-max-pixels", "0"]
+            with self.assertRaises(SystemExit):
+                create_index.parse_arguments()
+        finally:
+            sys.argv = original_argv
+
+    def test_load_search_embedding_backend_passes_qwen_max_pixels_only_to_qwen(self):
+        original_qwen = create_index.QwenVlEmbeddingBackend
+        original_openclip = create_index.OpenClipEmbeddingBackend
+        seen = {}
+
+        class FakeQwenBackend:
+            def __init__(self, model_id, device, output_dim=None, max_pixels=262144):
+                seen["qwen"] = (model_id, device, output_dim, max_pixels)
+
+        class FakeOpenClipBackend:
+            def __init__(self, model_name, pretrained, device):
+                seen["open_clip"] = (model_name, pretrained, device)
+
+        create_index.QwenVlEmbeddingBackend = FakeQwenBackend
+        create_index.OpenClipEmbeddingBackend = FakeOpenClipBackend
+        try:
+            qwen_args = types.SimpleNamespace(
+                search_backend="qwen_vl",
+                search_model_id="fake-qwen",
+                search_model_out_dim=64,
+                qwen_max_pixels=777,
+            )
+            create_index.load_search_embedding_backend(qwen_args, "cpu")
+            self.assertEqual(seen["qwen"], ("fake-qwen", "cpu", 64, 777))
+
+            open_clip_args = types.SimpleNamespace(
+                search_backend="open_clip",
+                search_model_name="ViT-L-14",
+                search_model_pretrained="openai",
+            )
+            create_index.load_search_embedding_backend(open_clip_args, "cpu")
+            self.assertEqual(seen["open_clip"], ("ViT-L-14", "openai", "cpu"))
+        finally:
+            create_index.QwenVlEmbeddingBackend = original_qwen
+            create_index.OpenClipEmbeddingBackend = original_openclip
+
     def test_pil_image_inputs_bypass_default_collate(self):
         tensor = create_index.torch.FakeTensor
         images = [create_index.Image.Image(), create_index.Image.Image()]


### PR DESCRIPTION
### Motivation
- Restrict Qwen3-VL image embedding input resolution by allowing a configurable maximum pixel count to avoid excessively large images and to match expected processor limits.
- Ensure the setting only affects the Qwen VL backend and can be supplied from the CLI with validation.

### Description
- Add a positive-integer argparse type `positive_int` and a `--qwen-max-pixels` CLI option (dest `qwen_max_pixels`) with default `262144` in `parse_arguments`.
- Extend `QwenVlEmbeddingBackend` with a `max_pixels` constructor argument, validate it via `_validate_max_pixels`, and call `configure_processor_image_limits` immediately after `AutoProcessor.from_pretrained` to set `processor.image_processor.max_pixels`.
- When `image_processor.size` is a dictionary containing `longest_edge`, update that key to the same `max_pixels` value and print the processor `min_pixels`/`max_pixels` via `print_qwen_processor_config` at startup.
- Thread the CLI value into backend construction in `load_search_embedding_backend` only for the Qwen VL backend, leaving other backends unaffected.
- Add unit tests in `tests/test_qwen_collate.py` to verify processor configuration, CLI default/custom/validation behavior, and that the `qwen_max_pixels` argument is passed only for Qwen backends.

### Testing
- `python -m py_compile create_index.py` completed successfully.
- `PYTHONPATH=. pytest -q tests/test_qwen_collate.py` succeeded (7 passed).
- `PYTHONPATH=. pytest -q` produced collection errors in this environment due to missing external dependencies (`PIL` / `flask`) and did not complete full test suite execution.
- `PYTHONPATH=. pytest -q tests/test_create_index_feature_routing.py` hit an unrelated existing test failure where the test `FakeTensor` lacks a `reshape` method; this appears pre-existing and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3378cd6fdc83248c47bfefbb7ceffc)