### PR TITLE
Use Qwen3VLModel for embedding inference

### DIFF
--- a/app/infrastructure/local_accessor.py
+++ b/app/infrastructure/local_accessor.py
@@ -56,12 +56,13 @@ class QwenEmbeddingBackend(SearchEmbeddingBackend):
     """Hugging FaceのQwen系埋め込みモデルを使う検索エンコーダ。"""
 
     def __init__(self, model_id: str) -> None:
-        from transformers import AutoModel, AutoProcessor
+        import transformers
+        from transformers import AutoProcessor
 
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         dtype = torch.float16 if self.device.startswith("cuda") else torch.float32
         self.processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
-        self.model = AutoModel.from_pretrained(
+        self.model = transformers.Qwen3VLModel.from_pretrained(
             model_id,
             torch_dtype=dtype,
             trust_remote_code=True,

--- a/create_index.py
+++ b/create_index.py
@@ -1341,7 +1341,8 @@ class QwenVlEmbeddingBackend(SearchEmbeddingBackend):
         output_dim: int | None = None,
         max_pixels: int = 262144,
     ):
-        from transformers import AutoModel, AutoProcessor
+        import transformers
+        from transformers import AutoProcessor
 
         self.device = device
         self.model_id = model_id
@@ -1351,7 +1352,7 @@ class QwenVlEmbeddingBackend(SearchEmbeddingBackend):
         self.processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
         self.configure_processor_image_limits(self.processor, self.max_pixels)
         self.print_qwen_processor_config(self.processor)
-        self.model = AutoModel.from_pretrained(
+        self.model = transformers.Qwen3VLModel.from_pretrained(
             model_id,
             torch_dtype=dtype,
             trust_remote_code=True,

--- a/qwen3_vl_embed_image_fixed.py
+++ b/qwen3_vl_embed_image_fixed.py
@@ -21,7 +21,8 @@ import torch
 import torch.nn.functional as F
 from PIL import Image
 from qwen_vl_utils.vision_process import process_vision_info
-from transformers import AutoModel, AutoProcessor
+import transformers
+from transformers import AutoProcessor
 
 
 DEFAULT_MODEL_ID = "Qwen/Qwen3-VL-Embedding-2B"
@@ -334,7 +335,7 @@ def main() -> int:
             padding_side="right",
             trust_remote_code=True,
         )
-        model = AutoModel.from_pretrained(
+        model = transformers.Qwen3VLModel.from_pretrained(
             args.model,
             dtype=dtype,
             attn_implementation=args.attention,

--- a/tests/test_qwen_collate.py
+++ b/tests/test_qwen_collate.py
@@ -327,7 +327,7 @@ class QwenCollateTests(unittest.TestCase):
             def parameters(self):
                 return iter([FakeParameter()])
 
-        class FakeAutoModel:
+        class FakeQwen3VLModel:
             @staticmethod
             def from_pretrained(model_id, torch_dtype=None, trust_remote_code=True):
                 calls["model_id"] = model_id
@@ -337,7 +337,7 @@ class QwenCollateTests(unittest.TestCase):
 
         transformers_mod = types.ModuleType("transformers")
         transformers_mod.AutoProcessor = FakeAutoProcessor
-        transformers_mod.AutoModel = FakeAutoModel
+        transformers_mod.Qwen3VLModel = FakeQwen3VLModel
         old_transformers = sys.modules.get("transformers")
         sys.modules["transformers"] = transformers_mod
         try:


### PR DESCRIPTION
### Motivation
- Calling the Qwen conditional-generation model triggers full-vocabulary `lm_head` logits which are unnecessary and expensive for embedding-only inference, so the backbone model should be used directly for embedding extraction. 

### Description
- Replace `AutoModel.from_pretrained(...)` usage with `transformers.Qwen3VLModel.from_pretrained(...)` for Qwen embedding backends in `app/infrastructure/local_accessor.py` and `create_index.py` to avoid computing generation logits. 
- Update the standalone script `qwen3_vl_embed_image_fixed.py` to instantiate `transformers.Qwen3VLModel` directly. 
- Add `import transformers` while keeping `AutoProcessor` usage for preprocessing. 
- Adjust `tests/test_qwen_collate.py` to mock `transformers.Qwen3VLModel` instead of `AutoModel` so the unit test matches the new load path. 

### Testing
- Ran `python -m py_compile app/infrastructure/local_accessor.py create_index.py qwen3_vl_embed_image_fixed.py tests/test_qwen_collate.py` which succeeded. 
- Ran `python -m unittest tests.test_qwen_collate` which passed. 
- Running `uv run pytest tests/test_qwen_collate.py` was blocked due to `onnxruntime-gpu` wheel not available for the CI Python (CPython 3.14). 
- Running full test discovery `python -m unittest discover -s tests` surfaced unrelated environment/mocking issues (missing `PIL`/`flask`, stub limitations for `tqdm`/`FakeTensor`) and one failing test in the current environment; these failures are due to test stubs and environment constraints rather than this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a337ea921a48324b6d78e9ada98e36d)