### PR TITLE
Limit UI model list to clip_meta indexes

### DIFF
--- a/app/infrastructure/local_repository.py
+++ b/app/infrastructure/local_repository.py
@@ -37,7 +37,6 @@ from app.domain.repository import Repository
 
 from PIL import Image as PILImage
 
-import open_clip
 
 @dataclass
 class _ScanProgress:
@@ -322,22 +321,16 @@ class LocalRepository(Repository):
 
     @cache
     def load_all_model_item(self) -> list[ModelItem]:
-        """利用可能な検索モデル一覧を返す。
+        """clip_meta に存在する検索モデル一覧を返す。
 
-        open_clip が提供する事前学習モデルに加えて、meta_dir 配下に
-        ``metafiles.index`` と ``sqlite_image_meta.db`` を持つインデックス
-        ディレクトリを検出し、UI で選択可能な ModelItem として追加する。
-        ``model_meta.json`` がある場合は、Qwen などの repo ID を安全な
-        ディレクトリ名へ変換したインデックスから元の ModelId と表示名を復元する。
+        meta_dir 配下に ``metafiles.index`` と ``sqlite_image_meta.db`` を持つ
+        インデックスディレクトリだけを検出し、UI で選択可能な
+        ModelItem として返す。``model_meta.json`` がある場合は、Qwen などの
+        repo ID を安全なディレクトリ名へ変換したインデックスから元の
+        ModelId と表示名を復元する。
         """
 
         items_by_key: dict[tuple[str, str], ModelItem] = {}
-
-        for model_name, dataset in open_clip.list_pretrained():
-            item = ModelItem(
-                ModelId(model_name, dataset), ModelName(f"{model_name}-{dataset}")
-            )
-            items_by_key[(model_name, dataset)] = item
 
         for index_dir in self._iter_search_index_dirs():
             item = self._model_item_from_index_dir(index_dir)

--- a/tests/test_local_repository_models.py
+++ b/tests/test_local_repository_models.py
@@ -1,0 +1,62 @@
+import pathlib
+import tempfile
+from unittest import TestCase
+
+from app.domain.domain_object import ModelId, ModelName
+from app.infrastructure.local_repository import LocalRepository
+from app.infrastructure.model_metadata import SearchModelMetadata, write_model_metadata
+
+
+class LocalRepositoryModelListTest(TestCase):
+    def _repository(self, meta_dir: pathlib.Path) -> LocalRepository:
+        return LocalRepository(pathlib.Path("/unused/images"), meta_dir)
+
+    def _create_index_dir(self, meta_dir: pathlib.Path, dirname: str) -> pathlib.Path:
+        index_dir = meta_dir / dirname
+        index_dir.mkdir(parents=True)
+        (index_dir / "metafiles.index").write_bytes(b"index")
+        (index_dir / "sqlite_image_meta.db").write_bytes(b"sqlite")
+        return index_dir
+
+    def test_load_all_model_item_uses_only_clip_meta_index_directories(self):
+        with tempfile.TemporaryDirectory() as temp_dir_name:
+            meta_dir = pathlib.Path(temp_dir_name)
+            self._create_index_dir(meta_dir, "ViT-L-14-openai")
+            incomplete_dir = meta_dir / "ViT-B-32-openai"
+            incomplete_dir.mkdir()
+            (incomplete_dir / "metafiles.index").write_bytes(b"index")
+
+            repo = self._repository(meta_dir)
+
+            items = repo.load_all_model_item()
+
+            self.assertEqual(
+                [item.id for item in items], [ModelId("ViT-L-14", "openai")]
+            )
+            self.assertEqual(
+                [item.display_name for item in items], [ModelName("ViT-L-14-openai")]
+            )
+
+    def test_load_all_model_item_restores_metadata_for_safe_directory_names(self):
+        with tempfile.TemporaryDirectory() as temp_dir_name:
+            meta_dir = pathlib.Path(temp_dir_name)
+            index_dir = self._create_index_dir(meta_dir, "Qwen--Qwen3-VL-Embedding-2B")
+            write_model_metadata(
+                index_dir,
+                SearchModelMetadata(
+                    "Qwen/Qwen3-VL-Embedding-2B",
+                    "",
+                    "Qwen/Qwen3-VL-Embedding-2B",
+                ),
+            )
+
+            items = self._repository(meta_dir).load_all_model_item()
+
+            self.assertEqual(
+                [item.id for item in items],
+                [ModelId("Qwen/Qwen3-VL-Embedding-2B", "")],
+            )
+            self.assertEqual(
+                [item.display_name for item in items],
+                [ModelName("Qwen/Qwen3-VL-Embedding-2B")],
+            )


### PR DESCRIPTION
### Motivation
- The UI should only offer models that have complete local search indexes in `clip_meta` rather than enumerating the full `open_clip` catalog.
- Keep the existing behavior that restores original `ModelId`/display name when a `model_meta.json` is present for safe directory names like Qwen repo IDs.

### Description
- Change `app/infrastructure/local_repository.py` to stop using `open_clip.list_pretrained()` and instead return only index-backed models discovered under the configured `meta_dir` (directories where `has_search_index` is true). 
- Remove the unused `open_clip` import from `app/infrastructure/local_repository.py` and update the `load_all_model_item` docstring to reflect the new behavior.
- Add unit tests in `tests/test_local_repository_models.py` to verify that only complete `clip_meta` index directories are returned and that `model_meta.json` restores original IDs for safe directory names.

### Testing
- Ran `python -m unittest tests.test_local_repository_models`, which passed (2 tests, `OK`).
- Ran `python -m unittest tests.test_local_repository_models tests.test_controller_model_params`, which failed due to the environment missing the `flask` dependency required by `tests.test_controller_model_params`.
- Attempted `uv run python -m unittest tests.test_local_repository_models`, which failed in this environment due to dependency resolution for `onnxruntime-gpu` on the current Python version (platform wheel mismatch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3487fbf16c83249c913bfd0d27c26e)