### PR TITLE
Fix Qwen UI pretrained selection

### DIFF
--- a/app/presentation/view/js/main.js
+++ b/app/presentation/view/js/main.js
@@ -103,6 +103,7 @@ const app = Vue.createApp({
             this.initImage()
         },
         model_name(){
+            if (this.syncPretrainedForSelectedModel()) return
             this.onModelChange()
         },
         pretrained(){
@@ -118,7 +119,7 @@ const app = Vue.createApp({
             const values = this.modelItems
                 .filter(item => item.model_name === this.model_name)
                 .map(item => item.pretrained)
-            return [...new Set([this.pretrained, ...values])]
+            return values.length > 0 ? [...new Set(values)] : [this.pretrained]
         },
     },
     methods:{
@@ -137,7 +138,21 @@ const app = Vue.createApp({
             return repository.getModelItems()
             .then(items => {
                 this.modelItems = items
+                this.syncPretrainedForSelectedModel()
             })
+        },
+
+        syncPretrainedForSelectedModel() {
+            const candidates = this.modelItems
+                .filter(item => item.model_name === this.model_name)
+                .map(item => item.pretrained)
+
+            if (candidates.length === 0 || candidates.includes(this.pretrained)) {
+                return false
+            }
+
+            this.pretrained = candidates[0]
+            return true
         },
 
         onModelChange(){


### PR DESCRIPTION
### Motivation
- The UI could keep a stale `pretrained` value (`openai`) when switching `model_name`, causing searches to reference `Qwen/Qwen3-VL-Embedding-2B-openai` instead of the intended Qwen index directory.  
- The change ensures the UI synchronizes `pretrained` with the selected model and limits the dropdown to valid `pretrained` candidates for the chosen model.

### Description
- Updated the model selection logic in `app/presentation/view/js/main.js` to add a new helper `syncPretrainedForSelectedModel()` that chooses a valid `pretrained` candidate for the current `model_name`.  
- Call `syncPretrainedForSelectedModel()` after loading model items and from the `model_name` watcher to avoid leaving an invalid `pretrained` value.  
- Changed the `pretrainedItems` computed property to return only valid candidate values for the selected model or fall back to the current `pretrained` when no candidates exist.

### Testing
- Ran `node --check app/presentation/view/js/main.js`, which completed successfully.  
- Ran `python -m pytest tests/test_controller_model_params.py tests/test_local_repository_models.py`, which failed during collection with `ModuleNotFoundError: No module named 'PIL'`.  
- Ran `uv run python -m pytest tests/test_controller_model_params.py tests/test_local_repository_models.py`, which failed because `uv` could not parse `uv.lock` due to conflict markers in the lockfile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3494eba46483248dad0b96016287a2)