### PR TITLE
Fix Qwen UI model path normalization

### DIFF
--- a/app/infrastructure/local_accessor.py
+++ b/app/infrastructure/local_accessor.py
@@ -27,6 +27,7 @@ from app.application.embedding_backend import SearchEmbeddingBackend, to_float32
 from app.infrastructure.model_metadata import (
     default_model_dir_name,
     has_search_index,
+    normalize_model_id,
     read_model_metadata,
     safe_model_dir_name,
 )
@@ -159,6 +160,7 @@ class LocalAccessor(Accessor):
 
     def _search_model_meta_dir(self, model_id: ModelId) -> pathlib.Path:
         """Return the index directory for a ModelId, including metadata-backed safe names."""
+        model_id = normalize_model_id(model_id)
         candidates = [
             self._meta_dir_path / default_model_dir_name(model_id),
             self._meta_dir_path / safe_model_dir_name(model_id.model_name),
@@ -211,6 +213,7 @@ class LocalAccessor(Accessor):
     def load_embedding_backend(self, model_id: ModelId) -> SearchEmbeddingBackend:
         """ModelIdからOpenCLIPまたはQwenの検索埋め込みバックエンドを返す。"""
 
+        model_id = normalize_model_id(model_id)
         if _is_qwen_model(model_id):
             return QwenEmbeddingBackend(_hf_model_name(model_id))
         return OpenClipEmbeddingBackend(model_id.model_name, model_id.pretrained)

--- a/app/infrastructure/model_metadata.py
+++ b/app/infrastructure/model_metadata.py
@@ -37,6 +37,19 @@ def default_model_dir_name(model_id: ModelId) -> str:
     return f"{model_id.model_name}-{model_id.pretrained}"
 
 
+def normalize_model_id(model_id: ModelId) -> ModelId:
+    """Normalize UI-supplied model IDs to the index layout used by create_index.py.
+
+    Non-OpenCLIP backends such as Qwen are stored by repository/model ID only
+    (for example ``Qwen--Qwen3-VL-Embedding-2B``) and do not have an OpenCLIP
+    pretrained tag. Older UI state can still submit ``pretrained="openai"``;
+    clear that stale value so lookups do not target ``Qwen/...-openai``.
+    """
+    if "/" in model_id.model_name and model_id.pretrained == "openai":
+        return ModelId(model_id.model_name, "")
+    return model_id
+
+
 def has_search_index(directory: pathlib.Path) -> bool:
     return (
         directory.is_dir()

--- a/app/presentation/controller.py
+++ b/app/presentation/controller.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from app.application.usecase import Usecase
 from app.domain.domain_object import ImageItem, ImageId, ModelId, ModelItem, ResultImageItemList, UploadImage, ResultImageItem, UploadText
+from app.infrastructure.model_metadata import normalize_model_id
 from app.logging_config import configure_logging
 
 
@@ -142,6 +143,10 @@ def get_request_params() -> dict:
     return body_params if request.method == "POST" else request.args
 
 
+def make_model_id(model_name: str, pretrained: str | None = "") -> ModelId:
+    return normalize_model_id(ModelId(model_name, pretrained or ""))
+
+
 def get_requested_model_id() -> ModelId:
     """リクエストパラメータから検索モデルIDを取り出す"""
 
@@ -150,7 +155,7 @@ def get_requested_model_id() -> ModelId:
     pretrained = params.get("pretrained", "")
     if model_name is None:
         abort(400, description="model_name is required")
-    return ModelId(model_name, pretrained or "")
+    return make_model_id(model_name, pretrained)
 
 
 def get_requested_image_ids() -> list[ImageId] | None:
@@ -206,7 +211,7 @@ def get_original_image(id: str):
 def search_text():
     """文字列から検索して、結果を返す"""
     args = ast.literal_eval(request.data.decode('utf-8')).get("params")
-    model_id: ModelId = ModelId(args.get("model_name"), args.get("pretrained"))
+    model_id: ModelId = make_model_id(args.get("model_name"), args.get("pretrained"))
     text: str = args.get("text")
     # 美感スコアの重要度を取得する。
     aesthetic_quality_beta: float = args.get("aesthetic_quality_beta")
@@ -233,7 +238,7 @@ def search_image():
     json_obj = json.loads(request.data).get("params")
 
     # 検索モデルのIDを取得する。
-    model_id: ModelId = ModelId(json_obj["model_name"], json_obj["pretrained"])
+    model_id: ModelId = make_model_id(json_obj["model_name"], json_obj["pretrained"])
 
     # 美感スコアの重要度を取得する。
     aesthetic_quality_beta: float = json_obj["aesthetic_quality_beta"]
@@ -255,7 +260,7 @@ def search_name():
     """名前から検索して、結果を返す"""
     args = ast.literal_eval(request.data.decode('utf-8')).get("params")
     # 検索モデルのIDを取得する。
-    model_id: ModelId = ModelId(args.get("model_name"), args.get("pretrained"))
+    model_id: ModelId = make_model_id(args.get("model_name"), args.get("pretrained"))
     text: str = args.get("text")
     is_regexp: bool = (args.get("is_regexp") == "true")
     # 美感スコアの重要度を取得する。
@@ -282,7 +287,7 @@ def search_upload_image():
 
     json_obj = json.loads(request.data).get("params")
 
-    model_id: ModelId = ModelId(json_obj["model_name"], json_obj["pretrained"])
+    model_id: ModelId = make_model_id(json_obj["model_name"], json_obj["pretrained"])
     base64_text: str = json_obj["base64"]
     content_type: str = json_obj.get("content_type", "image/png")
 
@@ -305,7 +310,7 @@ def search_random():
     json_obj = json.loads(request.data).get("params")
 
     # 検索モデルのIDを取得する。
-    model_id: ModelId = ModelId(json_obj["model_name"], json_obj["pretrained"])
+    model_id: ModelId = make_model_id(json_obj["model_name"], json_obj["pretrained"])
 
     # 美感スコアの重要度を取得する。
     aesthetic_quality_beta: float = json_obj["aesthetic_quality_beta"]
@@ -328,7 +333,7 @@ def search_query():
     json_obj = json.loads(request.data).get("params")
 
     # 検索モデルのIDを取得する。
-    model_id: ModelId = ModelId(json_obj["model_name"], json_obj["pretrained"])
+    model_id: ModelId = make_model_id(json_obj["model_name"], json_obj["pretrained"])
 
     search_query = json_obj["search_query"]
 
@@ -353,7 +358,7 @@ def add_text_features():
     json_obj = json.loads(request.data).get("params")
 
     # 検索モデルのIDを取得する。
-    model_id: ModelId = ModelId(json_obj["model_name"], json_obj["pretrained"])
+    model_id: ModelId = make_model_id(json_obj["model_name"], json_obj["pretrained"])
 
     text: str = json_obj["text"]
 
@@ -382,7 +387,7 @@ def search_tags():
     json_obj = json.loads(request.data).get("params")
 
     # 検索モデルのIDを取得する。
-    model_id: ModelId = ModelId(json_obj["model_name"], json_obj["pretrained"])
+    model_id: ModelId = make_model_id(json_obj["model_name"], json_obj["pretrained"])
 
     text: str = json_obj.get("text")
     is_regexp: bool = (json_obj.get("is_regexp") == "true")
@@ -406,7 +411,7 @@ def search_style_cluster():
 
     json_obj = json.loads(request.data).get("params")
 
-    model_id: ModelId = ModelId(json_obj["model_name"], json_obj["pretrained"])
+    model_id: ModelId = make_model_id(json_obj["model_name"], json_obj["pretrained"])
 
     text: str = json_obj.get("text")
     is_regexp: bool = (json_obj.get("is_regexp") == "true")

--- a/app/presentation/view/js/main.js
+++ b/app/presentation/view/js/main.js
@@ -147,7 +147,12 @@ const app = Vue.createApp({
                 .filter(item => item.model_name === this.model_name)
                 .map(item => item.pretrained)
 
-            if (candidates.length === 0 || candidates.includes(this.pretrained)) {
+            if (candidates.length === 0) {
+                return false
+            }
+
+            const preferred = candidates.find(value => value === this.pretrained)
+            if (preferred !== undefined && !(this.model_name.includes("/") && preferred === "openai")) {
                 return false
             }
 


### PR DESCRIPTION
## Summary
- Normalize stale UI `pretrained=openai` values for repository-style model IDs such as `Qwen/Qwen3-VL-Embedding-2B`.
- Ensure LocalAccessor resolves Qwen indexes to the safe directory created by `create_index.py` instead of `Qwen/...-openai`.
- Update the UI model/pretrained sync to prefer the discovered Qwen empty pretrained value over stale OpenCLIP defaults.

## Testing
- `python -m py_compile app/infrastructure/model_metadata.py app/infrastructure/local_accessor.py app/presentation/controller.py`
- `python -m unittest tests.test_controller_model_params tests.test_local_repository_models` (fails: missing PIL in environment)
- `uv run python -m unittest tests.test_controller_model_params tests.test_local_repository_models` (fails: existing uv.lock conflict markers prevent parsing)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34961d314883248568873e328cd8b0)